### PR TITLE
Use stahnma-puppetlabs_yum instead of reproducing the same logic

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -7,3 +7,4 @@ summary 'Install and manage Puppet open source'
 
 source 'https://github.com/puppetlabs-operations/puppet-puppet'
 project_page 'https://github.com/puppetlabs-operations/puppet-puppet'
+dependency 'stahnma/puppet-module-puppetlabs_yum', '>= 0.1.0'

--- a/manifests/package/repository.pp
+++ b/manifests/package/repository.pp
@@ -13,36 +13,10 @@
 # If used on apt based distributions, this requires the puppetlabs/apt module.
 #
 class puppet::package::repository($devel = false) {
-
   case $osfamily {
     Redhat: {
-      yumrepo { 'puppetlabs':
-        descr      => "Puppet Labs",
-        baseurl    => "http://yum.puppetlabs.com/el/5/products/$architecture/",
-        enabled    => 1,
-        gpgcheck   => 1,
-        keepalive  => 1,
-        gpgkey     => 'http://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs'
-      }
-
-      yumrepo { 'puppetlabs-deps':
-        descr      => "Puppet Labs",
-        baseurl    => "http://yum.puppetlabs.com/el/5/dependencies/$architecture/",
-        enabled    => 1,
-        gpgcheck   => 1,
-        keepalive  => 1,
-        gpgkey     => 'http://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs'
-      }
-
-      if $devel {
-        yumrepo { 'puppetlabs-devel':
-          descr      => "Puppet Labs Development packages",
-          baseurl    => "http://yum.puppetlabs.com/el/5/devel/$architecture/",
-          enabled    => 1,
-          gpgcheck   => 1,
-          keepalive  => 1,
-          gpgkey     => 'http://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs'
-        }
+      class { "puppetlabs_yum":
+        enable_devel   => $devel,
       }
     }
     Debian: {


### PR DESCRIPTION
This commit adds a module dependency on stahnma's puppetlabs_yum module. It
also removes some logic from the manifests/package/repository.pp and replaces
it with a puppetlabs_yum resource.
