### PR TITLE
print error when the operating system is not supported

### DIFF
--- a/manifests/params/defaults.pp
+++ b/manifests/params/defaults.pp
@@ -69,6 +69,7 @@ class puppet::params::defaults {
       $puppet_rundir      = '/var/lib/puppet/run/'
       $agent_service      = 'svc:/network/cswpuppetd'
     }
+    default: { fail("Sorry, $operatingsystem is not supported") }
   }
 
   # Behold, the list of platforms that have horrible package mangement!


### PR DESCRIPTION
without the above commit, the following misleading error is shown instead:

```
Error: Cannot alias File[/var/lib/puppet/concat/] to ["/var/lib/puppet/concat"] at /etc/puppet/modules/concat/manifests/init.pp:199; resource ["File", "/var/lib/puppet/concat"] already declared at /etc/puppet/modules/concat/manifests/setup.pp:49
```
