### PR TITLE
Extends regex for puppet 3.1.

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -129,7 +129,7 @@ class puppet::server (
         target => "${::puppet::params::puppet_confdir}/config.ru",
         source => $puppetversion ? {
           /^2.7/ => 'puppet:///modules/puppet/config.ru/99-run-2.7.rb',
-          /^3.0/ => 'puppet:///modules/puppet/config.ru/99-run-3.0.rb',
+          /^3.[0|1]/ => 'puppet:///modules/puppet/config.ru/99-run-3.0.rb',
         },
       }
     }


### PR DESCRIPTION
Previous to this commit the puppet::server class would fail when it
  couldn't match puppet version 3.1 to its selector for config.ru
  file.  This solves this by extending the selector's regex.
