### PR TITLE
Adding hiera default values

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -29,9 +29,9 @@
 #  }
 #
 class puppet::agent(
-  $server         = hiera('puppet::agent::server'),
-  $ca_server      = hiera('puppet::agent::server'),
-  $report_server  = hiera('puppet::agent::server'),
+  $server         = hiera('puppet::agent::server', 'puppet'),
+  $ca_server      = hiera('puppet::agent::server', 'puppet'),
+  $report_server  = hiera('puppet::agent::server', 'puppet'),
   $manage_service = undef,
   $method         = 'cron',
 ) {


### PR DESCRIPTION
While Hiera is not set properly (on the first run, for example) applying **puppet::agent** class will fail with _"Error: Could not find data item puppet::agent::server in any Hiera data file and no default supplied at /tmp/vagrant-puppet/modules-0/puppet/manifests/agent.pp:36 on node nodename"_.

With this change the **puppet::agent** will be successfully applied, albeit using the default value.

I think 'puppet' is a good default server name to use.
