### PR TITLE
fix the [main] generation

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -40,7 +40,7 @@ class puppet::agent(
   $manage_service = undef,
   $method         = 'cron',
   $ensure         = 'present',
-) {
+) inherits puppet::params {
 
   include puppet
 
@@ -56,6 +56,14 @@ class puppet::agent(
       notify { "Agent run method \"${method}\" is not supported by ${module_name}, defaulting to cron": loglevel => warning }
       class { 'puppet::agent::cron': manage_service => $manage_service }
     }
+  }
+
+  # ----
+  # puppet.conf management
+  concat::fragment { 'puppet.conf-main':
+    order   => '00',
+    target  => $puppet::params::puppet_conf,
+    content => template("puppet/puppet.conf/main.erb");
   }
 
   # ----

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,22 +7,8 @@
 #
 # This module should not be directly included.
 #
-class puppet (
-  $logdir = $puppet::params::puppet_logdir,
-  $vardir = $puppet::params::puppet_vardir,
-  $ssldir = $puppet::params::puppet_ssldir,
-  $rundir = $puppet::params::puppet_rundir,
-) inherits puppet::params {
-  include puppet::params
+class puppet {
   include concat::setup
-
-  # ----
-  # puppet.conf management
-  concat::fragment { 'puppet.conf-main':
-    order   => '00',
-    target  => $puppet::params::puppet_conf,
-    content => template("puppet/puppet.conf/main.erb");
-  }
 
   # ----
   # collect the puppet.conf fragments


### PR DESCRIPTION
puppet.conf/main.erb mentions the "server", "ca_server" and "report_server" 
variable, that are not present in manifests/init.pp. This results into empty
values in puppet.conf for the above variables. Moving the fragment to
manifests/agent.pp fixes the issue
