### PR TITLE
Add explicit dependencies to the agent class

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -100,4 +100,13 @@ class puppet::agent(
       class { 'puppet::agent::service': enable => false }
     }
   }
+
+  anchor { 'puppet::agent::begin': } ->
+  Class['::puppet'] ->
+  Class['::puppet::package'] ->
+  Class['::puppet::agent::config'] ->
+  Class['::puppet::agent::service'] ->
+  Class['::puppet::agent::cron'] ->
+  Class['::puppet::agent::monitor'] ->
+  anchor { 'puppet::agent::end': }
 }


### PR DESCRIPTION
This fixes an issue with dependency chaining. For example, attempting to enforce that an `apt::source` resource gets created before the `puppet::agent::package` class (see below for example) fails--the `puppet::agent::config` class is inserted at the top of the dependency graph and it attempts to install a version of puppet that is not available in the standard apt repositories.

This is an attempt to corral all the classes that `puppet::agent` depends on in a way that works with dependency chaining.

Both of the following examples failed on Ubuntu 12.04 running puppet version 3.1.1

``` puppet
    class { '::puppet::agent':
        ensure         => '3.4.2-1puppetlabs1',
        environment    => 'production',
        method         => 'cron',
        report         => false,
        server         => 'puppet',
        manage_repos   => true, #use modules repo management
    }
```

``` puppet
    apt::source { 'puppetlabs':
        location   => 'http://apt.puppetlabs.com',
        repos      => 'main dependencies',
        key        => '4BD6EC30',
        key_server => 'pgp.mit.edu',
    } ->
    class { '::puppet::agent':
        ensure         => '3.4.2-1puppetlabs1',
        environment    => 'production',
        method         => 'cron',
        report         => false,
        server         => 'puppet',
        manage_repos   => false, #manage repo ourselves
    }
```

I have not tested this change on a puppet master yet, but it works on the agents.
