### PR TITLE
(maint) Set the ca option

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -24,11 +24,9 @@ class puppet::server::config {
       value   => 'puppet';
   }
 
-  if $puppet::server::ca {
-    ini_setting { 'ca':
-      setting => 'ca',
-      value   => $puppet::server::ca,
-    }
+  ini_setting { 'ca':
+    setting => 'ca',
+    value   => $puppet::server::ca,
   }
 
   if $puppet::server::servertype == 'standalone' {


### PR DESCRIPTION
Puppet defaults to true, so if we only ever set the config version when
the value is true, this does us no good.

This change writes the ca value taken from the puppet::server class into
the master section of the puppet.conf configuration, regardless of the
value.  The module defaults to false here, so for any master that needs
to be the ca, this value is a change from what puppet defaults as.

We now always write what the module value is set to.
