### PR TITLE
Remove config.ru notification to Nginx::Vhost

### DIFF
--- a/manifests/server/rack.pp
+++ b/manifests/server/rack.pp
@@ -11,7 +11,6 @@ class puppet::server::rack {
     owner  => 'puppet',
     group  => 'puppet',
     mode   => '0644',
-    notify => Nginx::Vhost['puppetmaster'],
   }
 
   concat::fragment { "run-puppet-master":

--- a/manifests/server/thin.pp
+++ b/manifests/server/thin.pp
@@ -18,9 +18,10 @@ class puppet::server::thin {
   }
 
   thin::app { 'puppetmaster':
-    user    => 'puppet',
-    group   => 'puppet',
-    rackup  => "${::puppet::params::puppet_confdir}/config.ru",
-    chdir   => $puppet::params::puppet_confdir,
+    user      => 'puppet',
+    group     => 'puppet',
+    rackup    => "${::puppet::params::puppet_confdir}/config.ru",
+    chdir     => $puppet::params::puppet_confdir,
+    subscribe => Concat["${::puppet::params::puppet_confdir}/config.ru"],
   }
 }

--- a/manifests/server/unicorn.pp
+++ b/manifests/server/unicorn.pp
@@ -26,5 +26,6 @@ class puppet::server::unicorn {
     user            => 'puppet',
     group           => 'puppet',
     before          => Service['nginx'],
+    subscribe       => Concat["${::puppet::params::puppet_confdir}/config.ru"],
   }
 }


### PR DESCRIPTION
As far as I understand it, nginx would not actually care about changes to the rack server config.ru file. It might care about the location of the rack servers upstream socket or port, but this isn't defined in config.ru. I think this file is only relevant to the Rack compatible server being used, either Thin or Unicorn. So instead of notifying the Nginx::Vhost of changes, we need to subscribe to the config.ru Concat resource in the Thin::App and Unicorn::App resources.
