### PR TITLE
Send all graphite metrics in one payload.

### DIFF
--- a/files/reports/graphite.rb
+++ b/files/reports/graphite.rb
@@ -26,13 +26,15 @@ Puppet::Reports.register_report(:graphite) do
     Puppet.debug "Sending status for #{self.host} to Graphite server at #{GRAPHITE_SERVER}"
     prefix = GRAPHITE_PREFIX + '.' + self.host.split(".").reverse.join(".")
     epochtime = Time.now.utc.to_i
-    self.metrics.each { |metric,data|
-      data.values.each { |val| 
+    payload = self.metrics.map { |metric,data|
+      data.values.map { |val|
         name = "#{prefix}.puppet.#{val[1]}_#{metric}"
         value = val[2]
 
-        send_metric "#{name} #{value} #{epochtime}"
+        "#{name} #{value} #{epochtime}"
       }
     }
+
+    sent_metric payload.flatten.join("\n")
   end
 end


### PR DESCRIPTION
Should minimize the overhead of establishing a new TCP socket for each metric being sent.

I've tested this sending a copy of one of my system YAML reports to NC via TCPSocket#puts with one large string. I'm afraid I don't have a graphite instance to test with properly but this seemed like a good issue to get ticked off.

References puppetlabs-operations/puppet-puppet#62
