### PR TITLE
Update version range to support puppet 3.6

### DIFF
--- a/manifests/server/rack.pp
+++ b/manifests/server/rack.pp
@@ -20,7 +20,7 @@ class puppet::server::rack {
 
   $run_template = $puppetversion ? {
     /^2.7/      => 'puppet/config.ru/99-run-2.7.erb',
-    /^3.[0-5]/  => 'puppet/config.ru/99-run-3.0.erb',
+    /^3.[0-6]/  => 'puppet/config.ru/99-run-3.0.erb',
   }
 
   concat::fragment { "run-puppet-master":


### PR DESCRIPTION
It looks like the same rack erb template can be used for puppet 3.6.x as for 3.5.x
