### PR TITLE
fix a duplicate resource conflict

### DIFF
--- a/manifests/storeconfig/puppetdb.pp
+++ b/manifests/storeconfig/puppetdb.pp
@@ -19,7 +19,7 @@ class puppet::storeconfig::puppetdb(
     value   => 'puppetdb',
   }
 
-  ini_setting { 'puppetdb_server':
+  ini_setting { 'puppetdb_conf_server':
     ensure  => 'present',
     path    => "${::puppet::params::puppet_confdir}/puppetdb.conf",
     section => 'main',
@@ -27,7 +27,7 @@ class puppet::storeconfig::puppetdb(
     value   => $server,
   }
 
-  ini_setting { 'puppetdb_port':
+  ini_setting { 'puppetdb_conf_port':
     ensure  => 'present',
     path    => "${::puppet::params::puppet_confdir}/puppetdb.conf",
     section => 'main',


### PR DESCRIPTION
between this module and puppetlabs/puppetdb Ini_settings are named the
same. That causes a duplicate resource conflict when we try to run a
puppet server and a puppetdb server on the same node.
