### PR TITLE
simplify code by throwing away if/else

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -80,16 +80,9 @@ class puppet::server::config {
   }
 
   unless empty($puppet::server::reports) {
-    if is_array($puppet::server::reports) {
-      ini_setting { 'reports':
-        setting => 'reports',
-        value   => join($puppet::server::reports, ", "),
-      }
-    } else {
-      ini_setting { 'reports':
-        setting => 'reports',
-        value   => $puppet::server::reports,
-      }
+    ini_setting { 'reports':
+      setting => 'reports',
+      value   => join(flatten([ $puppet::server::reports ]), ', '),
     }
   }
 


### PR DESCRIPTION
we don't care if something is an array, because we can easily turn it
into an array, flatten it, and then run join on it. join won't do
anything for one element, so

``` puppet
    $scalar = 'baz'
    join(flatten([ $scalar ]), ', ')
```

still returns `baz`, whereas:

``` puppet
    $ary = ['foo', 'bar']
    join(flatten([ $ary ]), ', ')
```

does, indeed, return `foo, bar`
