### PR TITLE
Ensure future parser compatibility (quote string)

### DIFF
--- a/manifests/storeconfig/postgresql.pp
+++ b/manifests/storeconfig/postgresql.pp
@@ -37,12 +37,12 @@ class puppet::storeconfig::postgresql (
   # ---
   # Install the pg gem
   $package_name = $::operatingsystem ? {
-    FreeBSD => 'databases/rubygem-pg',
-    default => 'pg',
+    'FreeBSD' => 'databases/rubygem-pg',
+    default   => 'pg',
   }
   $package_provider  = $::operatingsystem ? {
-    FreeBSD => undef,
-    default => gem,
+    'FreeBSD' => undef,
+    default   => gem,
   }
   package { 'pg':
     ensure   => installed,


### PR DESCRIPTION
Since Puppet 3.5.1 the future parser no longer matches upper case words
in a selector statement as they are treated as a custom resource type.

See https://tickets.puppetlabs.com/browse/PUP-2800?focusedCommentId=76016&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-76016 for details.
