### PR TITLE
Add travis badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Puppet-puppet
+[![Build Status](https://travis-ci.org/puppetlabs-operations/puppet-puppet.svg?branch=master)](https://travis-ci.org/puppetlabs-operations/puppet-puppet)
 
 100% free range, organic, pesticide free Puppet module for managing Puppet.
+
 
 ## Usage
 


### PR DESCRIPTION
Putting the build status badge in the readme should help make the module more visibly trustworthy, and will make prospective developers aware of the tests before their pull requests get tested.
[ci skip]
