### PR TITLE
Make the inclusion of a service config optional.

### DIFF
--- a/manifests/agent/service.pp
+++ b/manifests/agent/service.pp
@@ -38,18 +38,20 @@ class puppet::agent::service (
     }
     default: {
 
-      $file_ensure = $puppet::params::agent_service_conf ? {
-        undef   => 'absent',
-        default => 'present',
-      }
+      if $puppet::params::agent_service_conf {
+        $file_ensure = $puppet::params::agent_service_conf ? {
+          undef   => 'absent',
+          default => 'present',
+        }
 
-      file { 'puppet_agent_service_conf':
-        ensure  => $file_ensure,
-        mode    => '0644',
-        owner   => 'root',
-        group   => 'root',
-        content => template('puppet/agent_service.erb'),
-        path    => $puppet::params::agent_service_conf,
+        file { 'puppet_agent_service_conf':
+          ensure  => $file_ensure,
+          mode    => '0644',
+          owner   => 'root',
+          group   => 'root',
+          content => template('puppet/agent_service.erb'),
+          path    => $puppet::params::agent_service_conf,
+        }
       }
     }
   }


### PR DESCRIPTION
  This commit will make it so that the service config is not required on
  all platforms.

  Without this we can't support Solaris.
