### PR TITLE
Quote case statements for future parser

### DIFF
--- a/manifests/package/repository.pp
+++ b/manifests/package/repository.pp
@@ -15,8 +15,8 @@
 class puppet::package::repository($devel = false) {
 
   case $::osfamily {
-    Redhat: { $repo_class = 'puppetlabs_yum' }
-    Debian: { $repo_class = 'puppetlabs_apt' }
+    'Redhat': { $repo_class = 'puppetlabs_yum' }
+    'Debian': { $repo_class = 'puppetlabs_apt' }
     default: { fail("Puppetlabs does not offer a package repository for ${::osfamily}") }
   }
 


### PR DESCRIPTION
Future parser (appears to) require that cases be quoted. Currently, using future parser always results in the default fail.
