### PR TITLE
Use the puppet default bindaddress

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -40,7 +40,7 @@ class puppet::server (
   $serverssl_protos   = undef,
   $serverssl_ciphers  = undef,
   $ca                 = false,
-  $bindaddress        = '::',
+  $bindaddress        = '0.0.0.0',
   $enc                = '',
   $enc_exec           = '',
   $servername         = undef,


### PR DESCRIPTION
Issue #69 makes a valid point.  Essentially the bindaddress does not
behave as expeted when IPv6 is not configured on the client.
