### PR TITLE
Added autosign and dns_alt_names parameters

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -49,6 +49,8 @@ class puppet::server (
   $gentoo_use         = $puppet::params::master_use,
   $gentoo_keywords    = $puppet::params::master_keywords,
   $manage_package     = true,
+  $dns_alt_names      = undef,
+  $autosign           = undef,
 ) inherits puppet::params {
 
   $master = true

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -123,4 +123,18 @@ class puppet::server::config {
     }
   }
 
+  if $puppet::server::dns_alt_names {
+    ini_setting { 'dns_alt_names':
+        setting => 'dns_alt_names',
+        value   =>  $puppet::server::dns_alt_names
+    }
+  }
+  
+  if $puppet::server::autosign {
+    ini_setting { 'autosign':
+        setting => 'autosign',
+        value   =>  $puppet::server::autosign
+    }
+  }
+
 }


### PR DESCRIPTION
Hi,

These changes would add 2 parameters:
- dns_alt_names: comma-separated list of alternative DNS names (doc: https://docs.puppetlabs.com/references/latest/configuration.html#dnsaltnames)
- autosign: a configuration file or a custom policy executable (doc: https://docs.puppetlabs.com/references/latest/configuration.html#autosign)

Note that you still need to add the custom policy executable via another method.
We embed a pre-shared key as a CSR attribute and a shell script on the master verifies if the CSR received from the agent contains this key.
The name/location of the script is passed as the autosign param.
