### PR TITLE
Tune group and user for OpenBSD

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,11 +13,13 @@ class puppet (
   $ssldir  = $puppet::params::puppet_ssldir,
   $rundir  = $puppet::params::puppet_rundir,
   $confdir = $puppet::params::puppet_confdir,
+  $user    = $puppet::params::puppet_user,
+  $group   = $puppet::params::puppet_group,
 ) inherits puppet::params {
 
   file { $confdir:
     ensure => 'directory',
-    owner  => 'puppet',
-    group  => 'puppet',
+    owner  => $user,
+    group  => $group,
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -125,4 +125,14 @@ class puppet::params {
     }
     default: { fail("Sorry, ${::operatingsystem} is not supported") }
   }
+
+  $puppet_user = $::osfamily ? {
+    'OpenBSD' => '_puppet',
+    default   => 'puppet',
+  }
+
+  $puppet_group = $::osfamily ? {
+    'OpenBSD' => '_puppet',
+    default   => 'puppet',
+  }
 }


### PR DESCRIPTION
This work ensures that the agent configuration will use the group and
user native to the given platform for permission handling.
