### PR TITLE
Fix broken nginx-unicorn support

### DIFF
--- a/manifests/server/rack.pp
+++ b/manifests/server/rack.pp
@@ -20,7 +20,7 @@ class puppet::server::rack {
 
   $run_template = $::puppetversion ? {
     /^2.7/      => 'puppet/config.ru/99-run-2.7.erb',
-    /^3.[0-6]/  => 'puppet/config.ru/99-run-3.0.erb',
+    /^3.[0-7]/  => 'puppet/config.ru/99-run-3.0.erb',
   }
 
   concat::fragment { 'run-puppet-master':

--- a/manifests/server/unicorn.pp
+++ b/manifests/server/unicorn.pp
@@ -2,7 +2,7 @@ class puppet::server::unicorn {
 
   include puppet::params
   include puppet::server::rack
-  class { 'nginx': }
+  include nginx
 
   class { 'puppet::server::standalone':
     enabled => false,
@@ -11,31 +11,63 @@ class puppet::server::unicorn {
       Unicorn::App['puppetmaster'],
     ],
   }
+  Ini_setting {
+    ensure  => 'present',
+    section => 'master',
+    path    => $puppet::params::puppet_conf,
+  }
+  ini_setting {
+    'ssl_client_header':
+      ensure  => present,
+      setting => 'ssl_client_header',
+      value   => 'HTTP_X_CLIENT_DN';
+    'ssl_client_verify_header':
+      ensure  => present,
+      setting => 'ssl_client_verify_header',
+      value   => 'HTTP_X_CLIENT_VERIFY';
+  }
 
   $servername     = pick($::puppet::server::servername, $::clientcert, $::fqdn)
   $unicorn_socket = "unix:${puppet::params::puppet_rundir}/puppetmaster_unicorn.sock"
 
   nginx::resource::vhost { 'puppetmaster':
-    server_name           => [$servername],
-    ssl                   => true,
-    ssl_port              => '8140',
-    listen_port           => '8140', # force ssl_only by matching ssl_port
-    ssl_cert              => "${::puppet::ssldir}/certs/${servername}.pem",
-    ssl_key               => "${::puppet::ssldir}/private_keys/${servername}.pem",
-    ssl_ciphers           => $::puppet::server::ssl_ciphers,
-    ssl_protocols         => $::puppet::server::ssl_protocols,
-    proxy_read_timeout    => '300',
-    proxy                 => "http://puppetmaster_unicorn",
-    vhost_cfg_append      => {
+    server_name          => [$servername],
+    ssl                  => true,
+    ssl_port             => '8140',
+    listen_port          => '8140', # force ssl_only by matching ssl_port
+    ssl_cert             => "${::puppet::ssldir}/certs/${servername}.pem",
+    ssl_key              => "${::puppet::ssldir}/private_keys/${servername}.pem",
+    ssl_ciphers          => $::puppet::server::ssl_ciphers,
+    ssl_protocols        => $::puppet::server::ssl_protocols,
+    use_default_location => false,
+    vhost_cfg_append     => {
       ssl_crl                => "${::puppet::ssldir}/crl.pem",
       ssl_client_certificate => "${::puppet::ssldir}/certs/ca.pem",
       ssl_verify_client      => 'optional',
-      proxy_connect_timeout  => '300',
-      proxy_set_header       => [ 'Host $host', 'X-Real-IP $remote_addr', 'X-Forwarded-For $proxy_add_x_forwarded_for', 'X-Client-Verify $ssl_client_verify', 'X-Client-DN $ssl_client_s_dn', 'X-SSL-Issuer $ssl_client_i_dn'],
+      proxy_set_header       => [ 'Host $host',
+                                  'X-Real-IP $remote_addr',
+                                  'X-Forwarded-For $proxy_add_x_forwarded_for',
+                                  'X-Client-Verify $ssl_client_verify',
+                                  'X-Client-DN $ssl_client_s_dn',
+                                  'X-SSL-Issuer $ssl_client_i_dn'],
       root                   => '/usr/share/empty',
     }
   }
-
+  nginx::resource::location { 'unicorn_upstream':
+    ensure                => present,
+    location              => '/',
+    vhost                 => 'puppetmaster',
+    proxy_set_header      => [],
+    location_custom_cfg   => {
+      proxy_pass            => "http://puppetmaster_unicorn",
+      proxy_redirect        => 'off',
+      proxy_connect_timeout => '90',
+      proxy_read_timeout    => '300',
+    },
+    # this priority sets concat order so that the location is created inside
+    # the server block. This works around a possible bug in jfryman/nginx.
+    priority => 701,
+  }
   nginx::resource::upstream { 'puppetmaster_unicorn':
     members => [
       $unicorn_socket

--- a/spec/acceptance/server_spec.rb
+++ b/spec/acceptance/server_spec.rb
@@ -94,6 +94,11 @@ describe 'server', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily')) d
       apply_manifest(pp, :catch_failures => true)
       expect(apply_manifest(pp, :catch_failures => true).exit_code).to be_zero
     end
+  describe command('puppet agent --test --server puppet') do
+    its(:exit_status) { should eq 0 }
+    its(:stderr) { should_not match /Forbidden request:/ }
+    its(:stderr) { should_not match /Error:/ }
+  end
 
     describe package('nginx') do
       it {

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -33,6 +33,7 @@ masters.each do |host|
   install_package host, 'rubygems'
   install_package host, 'git'
   on host, 'hash r10k || gem install r10k --no-ri --no-rdoc'
+  on host, 'echo "$(facter ipaddress) puppet" >> /etc/hosts'
 
   puppetfile = <<-EOS
 mod 'stdlib',         :git => 'git://github.com/puppetlabs/puppetlabs-stdlib.git'
@@ -47,7 +48,7 @@ mod 'interval',       :git => 'git://github.com/puppetlabs-operations/puppet-int
 mod 'unicorn',        :git => 'git://github.com/puppetlabs-operations/puppet-unicorn.git'
 mod 'rack',           :git => 'git://github.com/puppetlabs-operations/puppet-rack.git'
 mod 'bundler',        :git => 'git://github.com/puppetlabs-operations/puppet-bundler.git'
-mod 'nginx',          :git => 'git://github.com/jfryman/puppet-nginx.git'
+mod 'nginx',          :git => 'git://github.com/jfryman/puppet-nginx.git', :ref => 'v0.0.10'
 mod 'inifile',        :git => 'git://github.com/puppetlabs/puppetlabs-inifile.git'
 mod 'apache',         :git => 'git://github.com/puppetlabs/puppetlabs-apache.git'
 mod 'portage',        :git => 'git://github.com/gentoo/puppet-portage.git'


### PR DESCRIPTION
addresses puppet-puppet issue 119 by switching from using the default
location in the vhost to using an explicitly defined location, in
order to avoid the default headers that cannot be unset on the default
location.

Add beaker tests to test for this problem
Note that the beaker tests for this specific issue pass, but there are still failures.
I think it's better to get this fixed and add tests rather than blocking
on fixing everything.

Also updates rack case statement to support puppet 3.7.x
