### PR TITLE
Update travis test scope

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,18 +5,21 @@ before_install: rm Gemfile.lock || true
 rvm:
   - 1.9.3
   - 2.0.0
+  - 2.1.3
 script: bundle exec rake test
 env:
-  - PUPPET_VERSION="~> 2.7.0"
   - PUPPET_VERSION="~> 3.1.0"
   - PUPPET_VERSION="~> 3.2.0"
   - PUPPET_VERSION="~> 3.3.0"
   - PUPPET_VERSION="~> 3.4.0"
+  - PUPPET_VERSION="~> 3.7.3"
 matrix:
   exclude:
   - rvm: 2.0.0
-    env: PUPPET_VERSION="~> 2.7.0"
-  - rvm: 2.0.0
     env: PUPPET_VERSION="~> 3.1.0"
-  - rvm: 1.9.3
-    env: PUPPET_VERSION="~> 2.7.0"
+  - rvm: 2.1.3
+    env: PUPPET_VERSION="~> 3.1.0"
+  - rvm: 2.1.3
+    env: PUPPET_VERSION="~> 3.2.0"
+  - rvm: 2.1.3
+    env: PUPPET_VERSION="~> 3.3.0"


### PR DESCRIPTION
Drop puppet 2.7 testing - 2.7.x is no longer supported/maintained by Puppet Labs, so I don't think we need to continue to support it in this module.
Add puppet 3.7.3 testing
Add ruby 2.1.3 testing (but not for puppet 3.1, 3.2, 3.3 because it fails. Ruby 2.1 [only officially supported on puppet 3.5 and higher](https://docs.puppetlabs.com/guides/platforms.html))
