### PR TITLE
Move logic about where reports dir is

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -135,4 +135,6 @@ class puppet::params {
     'OpenBSD' => '_puppet',
     default   => 'puppet',
   }
+
+  $report_dir = '/usr/lib/ruby/vendor_ruby/puppet/reports'
 }

--- a/manifests/reports.pp
+++ b/manifests/reports.pp
@@ -1,6 +1,0 @@
-class puppet::reports {
-  $report_dir = $::puppet_major_version ? {
-    '3' => '/usr/lib/ruby/vendor_ruby/puppet/reports',
-    '2' => '/usr/lib/ruby/1.8/puppet/reports',
-  }
-}

--- a/manifests/reports/graphite.pp
+++ b/manifests/reports/graphite.pp
@@ -3,14 +3,12 @@
 #
 class puppet::reports::graphite($server, $port, $prefix) {
 
-  include puppet::reports
-
   # This is a little bit dirty, as it just throws it straight in the
   # rubylib, but it's better than messing with libdir on the master.
   # See https://projects.puppetlabs.com/issues/4345 for mild
   # discussion.
   file{
-    "/${puppet::reports::report_dir}/graphite.rb":
+    "/${puppet::server::report_dir}/graphite.rb":
       ensure => present,
       owner  => 'root',
       group  => 'root',

--- a/manifests/reports/irccat.pp
+++ b/manifests/reports/irccat.pp
@@ -9,14 +9,12 @@ class puppet::reports::irccat($host, $githuburl, $dashboard, $ignore_hosts = [])
     'httparty':;
   }
 
-  require puppet::reports
-
   # This is a little bit dirty, as it just throws it straight in the
   # rubylib, but it's better than messing with libdir on the master.
   # See https://projects.puppetlabs.com/issues/4345 for mild
   # discussion.
   file{
-    "${puppet::reports::report_dir}/irccat.rb":
+    "${puppet::server::report_dir}/irccat.rb":
       ensure => present,
       owner  => 'root',
       group  => 'root',

--- a/manifests/reports/xmpp.pp
+++ b/manifests/reports/xmpp.pp
@@ -12,14 +12,12 @@ class puppet::reports::xmpp($jid, $password, $dashboard, $target = [], $ignore_h
     'httparty':;
   }
 
-  include puppet::reports
-
   # This is a little bit dirty, as it just throws it straight in the
   # rubylib, but it's better than messing with libdir on the master.
   # See https://projects.puppetlabs.com/issues/4345 for mild
   # discussion.
   file{
-    "${puppet::reports::report_dir}/xmpp.rb":
+    "${puppet::server::report_dir}/xmpp.rb":
       ensure => present,
       owner  => 'root',
       group  => 'root',

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -44,6 +44,7 @@ class puppet::server (
   $parser             = undef,
   $manage_puppetdb    = undef,
   $report             = true,
+  $report_dir         = $puppet::params::report_dir,
   $reportfrom         = undef,
   $reports            = ['store', 'https'],
   $reporturl          = "http://${::fqdn}/reports",


### PR DESCRIPTION
Makes more sense in params.pp than as the only thing in reports.pp
Doesn't need to be a conditional anymore if we're dropping 2.x support
(also highlights that it's probably wrong on *BSD)
