### PR TITLE
Move puppet::passenger to puppet::master::passenger

### DIFF
--- a/manifests/server/passenger.pp
+++ b/manifests/server/passenger.pp
@@ -1,8 +1,59 @@
 class puppet::server::passenger {
-
   class { 'puppet::server::standalone': enabled => false }
 
-  if $::kernel != 'Darwin' {
-    include puppet::passenger
+  if $::kernel == 'Darwin' {
+    fail('puppet::server::passenger not supported on OS X')
+  }
+
+  include apache
+  include apache::mod::ssl
+  include apache::mod::passenger
+
+  file { ['/etc/puppet/rack', '/etc/puppet/rack/public/', '/etc/puppet/rack/tmp']:
+      ensure => directory,
+      owner  => 'puppet',
+      group  => 'puppet',
+  }
+
+  $source   = $::puppetversion ? {
+    /^2.7/ => 'puppet:///modules/puppet/config.ru.passenger.27',
+    /^3./  => 'puppet:///modules/puppet/config.ru.passenger.3',
+  }
+
+  file { '/etc/puppet/rack/config.ru':
+    owner    => 'puppet',
+    group    => 'puppet',
+    mode     => '0644',
+    source   => $source,
+  }
+
+  if $puppet::server::bindaddress == '::' {
+    $ip = '*'
+  } else {
+    $ip = $puppet::server::bindaddress
+  }
+
+  apache::vhost { 'puppetmaster':
+    servername        => $puppet::server::servername,
+    ip                => $ip,
+    port              => '8140',
+    priority          => '10',
+    docroot           => '/etc/puppet/rack/public/',
+    ssl               => true,
+    ssl_cipher        => $puppet::server::ssl_ciphers,
+    ssl_protocol      => $puppet::server::ssl_protocols,
+    ssl_cert          => "${puppet::ssldir}/certs/${puppet::server::servername}.pem",
+    ssl_key           => "${puppet::ssldir}/private_keys/${puppet::server::servername}.pem",
+    ssl_chain         => "${puppet::ssldir}/certs/ca.pem",
+    ssl_ca            => "${puppet::ssldir}/ca/ca_crt.pem",
+    ssl_crl           => "${puppet::ssldir}/ca/ca_crl.pem",
+    ssl_verify_client => 'optional',
+    ssl_verify_depth  => '1',
+    ssl_options       => ['+StdEnvVars', '+ExportCertData'],
+    request_headers   => [
+      'set X-SSL-Subject %{SSL_CLIENT_S_DN}e',
+      'set X-Client-DN %{SSL_CLIENT_S_DN}e',
+      'set X-Client-Verify %{SSL_CLIENT_VERIFY}e',
+    ],
   }
 }

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -103,7 +103,7 @@ describe 'puppet::server' do
         it_behaves_like "basic puppetmaster config"
 
         # Tests specific to passenger server
-        it { should contain_class('puppet::passenger') }
+        it { should contain_class('puppet::server::passenger') }
         it { should contain_class('apache') }
         it { should contain_class('apache::mod::passenger') }
 

--- a/tests/passenger.pp
+++ b/tests/passenger.pp
@@ -1,1 +1,5 @@
-include puppet::passenger
+class { 'puppet::server':
+  servertype => 'passenger',
+  ca         => true,
+}
+


### PR DESCRIPTION
This makes it consistent with how the nginx/unicorn master code is organized. 

This should probably not get merged until @igalic has had a chance to comment, since he's using this module with passenger. 

This isn't super important, I just noticed that it was inconsistent while working on documentation.
