### PR TITLE
Enable / manage structured facts

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -50,6 +50,7 @@ class puppet::agent(
   $gentoo_use        = $puppet::params::agent_use,
   $gentoo_keywords   = $puppet::params::agent_keywords,
   $manage_package    = true,
+  $stringify_facts   = $puppet::server::stringify_facts,
 ) inherits puppet::params {
 
   include puppet

--- a/manifests/agent/config.pp
+++ b/manifests/agent/config.pp
@@ -105,4 +105,10 @@ class puppet::agent::config {
     setting => 'usecacheonfailure',
     value   => $puppet::agent::usecacheonfailure,
   }
+
+  ini_setting { 'stringify_facts_agent':
+      setting => 'stringify_facts',
+      section => 'main',
+      value   => $puppet::agent::stringify_facts;
+  }
 }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -52,6 +52,7 @@ class puppet::server (
   $serverssl_protos   = undef,
   $servertype         = 'unicorn',
   $storeconfigs       = undef,
+  $stringify_facts    = false,
 ) inherits puppet::params {
 
   $master = true

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -40,6 +40,11 @@ class puppet::server::config {
     'group':
       setting => 'group',
       value   => 'puppet';
+
+    'stringify_facts_master':
+      setting => 'stringify_facts',
+      section => 'main',
+      value   => $puppet::server::stringify_facts;
   }
 
   ini_setting { 'ca':


### PR DESCRIPTION
This adds a parameter to manage structured facts. You can manage them separately on agent and master, but the agent defaults to being set to whatever the master is using.

The only controversial change here might be that I'm enabling structured facts (disabling stringify_facts) by default, because I want to use structured facts in the new puppet server code I'm working on. Out of the box, puppet comes with structured facts disabled. I'd be open to switching the default if people have concerns.

Given that [structured facts will be the default in puppet 4](https://docs.puppetlabs.com/references/latest/configuration.html#stringifyfacts) this seems reasonable to me.
