### PR TITLE
Add a travis test with coming-soon options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ env:
   - PUPPET_VERSION="~> 3.3.0"
   - PUPPET_VERSION="~> 3.4.0"
   - PUPPET_VERSION="~> 3.7.3"
+  - PUPPET_VERSION="~> 3.7.3" FUTURE_PARSER=yes
+  - PUPPET_VERSION="~> 3.7.3" STRINGIFY_FACTS=no
+  - PUPPET_VERSION="~> 3.7.3" STRICT_VARIABLES=yes
+  - PUPPET_VERSION="~> 3.7.3" ORDERING=random
 matrix:
   exclude:
   - rvm: 2.0.0
@@ -23,3 +27,5 @@ matrix:
     env: PUPPET_VERSION="~> 3.2.0"
   - rvm: 2.1.3
     env: PUPPET_VERSION="~> 3.3.0"
+  allow_failures:
+    - env: PUPPET_VERSION="~> 3.7.3" STRICT_VARIABLES=yes


### PR DESCRIPTION
This just adds one additional test on travis that has future parser, strict variables, and randomizes ordering. We can break them out, but I figured it'd be good to catch it at all. Strict variables are expected to fail but it's allowed in travis and helps demonstrate that it needs fixing eventually.

These simply feed into https://github.com/puppetlabs/puppetlabs_spec_helper/blob/65f150f03f73329ca380cf3016f73b264df8b3cb/lib/puppetlabs_spec_helper/module_spec_helper.rb

The idea behind random ordering is that it acts as sort of an implicit fuzzer to find dependency ordering we're not aware of, by changing order randomly rather than using resource hash ordering.

Edit: it broke right away, so I separated them out to make more clear which test failed.
