### PR TITLE
Add Puppet Forge deployment via travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,37 @@
----
 language: ruby
-bundler_args: --without development
 before_install: rm Gemfile.lock || true
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1.3
-script: bundle exec rake test
+- 1.9.3
+- 2.0.0
+- 2.1.3
+script:
+- bundle exec rake test
 env:
-  - PUPPET_VERSION="~> 3.1.0"
-  - PUPPET_VERSION="~> 3.2.0"
-  - PUPPET_VERSION="~> 3.3.0"
+  matrix:
   - PUPPET_VERSION="~> 3.4.0"
+  - PUPPET_VERSION="~> 3.6.2"
   - PUPPET_VERSION="~> 3.7.3"
   - PUPPET_VERSION="~> 3.7.3" FUTURE_PARSER=yes
   - PUPPET_VERSION="~> 3.7.3" STRINGIFY_FACTS=no
-  - PUPPET_VERSION="~> 3.7.3" STRICT_VARIABLES=yes
   - PUPPET_VERSION="~> 3.7.3" ORDERING=random
-matrix:
-  exclude:
-  - rvm: 2.0.0
-    env: PUPPET_VERSION="~> 3.1.0"
-  - rvm: 2.1.3
-    env: PUPPET_VERSION="~> 3.1.0"
-  - rvm: 2.1.3
-    env: PUPPET_VERSION="~> 3.2.0"
-  - rvm: 2.1.3
-    env: PUPPET_VERSION="~> 3.3.0"
-  allow_failures:
-    - env: PUPPET_VERSION="~> 3.7.3" STRICT_VARIABLES=yes
+  global:
+  - secure: b8ILGtahVLc1ayqqD4FTVzvhYTmgCIzovV4vEgw33K3b6Y4dswzfkFVXFe7rgtCe6mm+7/elhMYA7nLA9pKfwjSTWRYqML0o90XbtnpSXlAWFRFfE+mvk6VGrjLWXRb/ZdfJQhnZb5g9uU18jhsirIqrtj54d223BBU5F6zuSAg=
+  - secure: GS2TnEvz0rKXT5qRmaw9DPD1T14PxTWsCDmQU/ZCY81ZyVkegsqQZgUujM9ZHGEu8zjRhPiNp9nHvMJuqWWKgZLryJl+3zQSR4bbcdBMd2eB4J8D3MmMaRFCY6DDMyuOdMNqCB6oUl0d84lKl1kdDtRibCTX+ihANvL6qEEeUFg=
+after_success:
+- curl -o travis_after_all.py https://raw.githubusercontent.com/dmakhno/travis_after_all/b7172bca92d6dcfcec2a0eacdf14eb5f3a1ad627/travis_after_all.py
+- python travis_after_all.py
+- export $(cat .to_export_back)
+- "./travis/deploy.sh"
+after_failure:
+- python travis_after_all.py
+- export $(cat .to_export_back)
+- |
+  if [ "$BUILD_LEADER" = "YES" ]; then
+    if [ "$BUILD_AGGREGATE_STATUS" = "others_failed" ]; then
+      echo "All Failed"
+    else
+      echo "Some Failed"
+    fi
+  fi
+after_script:
+- echo leader=$BUILD_LEADER status=$BUILD_AGGREGATE_STATUS

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,3 +89,34 @@ vagrant up agent
 vagrant ssh agent
 sudo puppet agent --test --waitforcert 10 --server puppet
 ```
+
+How to Deploy to Puppet Forge
+=============================
+
+To perform a release:
+
+1) Update the metadata.json file with the new version, and commit the change
+2) Tag that commit with an annotated commit: `git tag -a 0.13.0 -m 'release 0.13.0'`
+3) Make a pull request so that another contributor can merge the PR
+4) When that commit is merged, travis-ci will run and deploy to Puppet Forge
+5) Check the travis-ci output and forge site to verify that it deployed
+
+Versioning
+----------
+Release versions should follow [semver](http://semver.org/) guidelines:
+
+> Given a version number MAJOR.MINOR.PATCH, increment the:
+>
+> MAJOR version when you make incompatible API changes,
+> MINOR version when you add functionality in a backwards-compatible manner, and
+> PATCH version when you make backwards-compatible bug fixes.
+
+Update Changelog
+----------------
+Notable changes should be added to [CHANGELOG](CHANGELOG).
+
+Run Beaker Tests
+----------------
+Pplease run beaker acceptance test suite before releasing. At the moment,
+those tests only run manually, without any Jenkins/CI-triggered acceptance
+tests. At the very least, the acceptance tests should be run for Debian 7.

--- a/metadata.json
+++ b/metadata.json
@@ -5,7 +5,7 @@
   "author": "Puppet Labs Operations",
   "license": "Apache 2",
   "summary": "Install and manage Puppet open source",
-  "description": "UNKNOWN",
+  "description": "Install and manage Puppet open source masters and agents",
   "project_page": "https://github.com/puppetlabs-operations/puppet-puppet",
   "dependencies": [
     {
@@ -58,10 +58,6 @@
     }
   ],
   "requirements": [
-    {
-      "name": "pe",
-      "version_requirement": "3.x"
-    },
     {
       "name": "puppet",
       "version_requirement": "3.x"

--- a/travis/deploy.sh
+++ b/travis/deploy.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# This script runs the deploy process for travis-ci builds
+# Travis-ci will call the script after builds are successful
+#
+# In order to trigger a module build and deployment to puppet forge, the
+# following conditions must be met:
+# - Git commit is in master branch
+# - Git commit is tagged and the tag is the same version as in metadata.json
+# - All builds in travis were successful
+# - The current build is not for a pull request
+
+# Additionally, a few other sanity checks are in place to prevent unwanted
+# deployments or deployment attempts
+
+# Only deploy if this is being built for puppetlabs-operations/puppet-puppet
+# this is to avoid deploy attempts when forks run through travis-ci
+# if you really do want to deploy your fork to the forge, just disable this
+if [ "$TRAVIS_REPO_SLUG" != "puppetlabs-operations/puppet-puppet" ]; then
+  echo 'this build is not being built on puppetlabs-operations/puppet-puppet'
+  echo 'no deploy scheduled'
+fi
+
+# Only deploy if this is not being built for a pull request
+if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+  echo 'this build is for a pull request; no deploy scheduled'
+  exit 0
+fi
+
+# Only deploy for builds of the master branch
+if [ "$TRAVIS_BRANCH" != "master" ]; then
+  echo 'this build is not for the master branch; no deploy scheduled'
+  exit 0
+fi
+
+# Only deploy if this is the build leader in travis
+if [ "$BUILD_LEADER" != "YES" ]; then
+  echo "not build leader, no deploy scheduled"
+  exit 0
+fi
+
+# Only deploy if all other builds succeeded
+if [ "$BUILD_AGGREGATE_STATUS" != "others_succeeded" ]; then
+  echo "Some Failed, no deploy scheduled"
+  exit 0
+fi
+
+# Only deploy if the current commit was tagged in git
+if [ -z "$TRAVIS_TAG" ]; then
+  echo "TRAVIS_TAG is nil, no deploy scheduled because the commit lacks a tag"
+  exit 0
+else
+  echo "detected tag: ${TRAVIS_TAG}, continuing with deploy"
+fi
+
+compare_versions() {
+  # Only deploy if current tag equals the version in metadata.json
+  # If we forgot to update metadata.json, bail and do not deploy
+  echo "Verifying that version in TRAVIS_TAG matches version in metadata.json"
+  sudo apt-get update
+  sudo apt-get install -y jq
+  METADATA_VERSION="$(jq -r .version < metadata.json)"
+  if [ "$TRAVIS_TAG" != "$METADATA_VERSION" ]; then
+    echo "Error: Git tag does not equal version in metadata.json! Exiting."
+    exit 1
+  else
+    return 0
+  fi
+}
+
+create_blacksmith_auth_file() {
+  if [ -z "$FORGE_USERNAME" ] || [ -z "$FORGE_PASSWORD" ]; then
+    echo "FORGE_USERNAME and/or FORGE_PASSWORD are unset, exiting"
+    exit 0
+  fi
+
+  cat > ~/.puppetforge.yml << EOF
+url: https://forgeapi.puppetlabs.com
+username: ${FORGE_USERNAME}
+password: ${FORGE_PASSWORD}
+EOF
+}
+
+deploy_module() {
+  echo "All Succeded! PUBLISHING..."
+  bundle install
+  bundle exec rake build
+  bundle exec rake module:push
+}
+
+create_blacksmith_auth_file
+compare_versions
+deploy_module


### PR DESCRIPTION
This PR adds the ability to publish forge releases by updating the metadata.json file, tagging the resulting commit, and making a PR. When the PR is merged, travis-ci will publish to [ploperations/puppet](https://forge.puppetlabs.com/ploperations/puppet) on Puppet Forge.

I'm not sure whether this is how we want to do this. Here's what I like and don't like about this approach:

_Advantages_
- Very easy to cut new releases, and allows releases to follow the PR workflow
- No additional infrastructure needed because it runs through travis-ci
- We probably get a new forge release pretty soon

_Disadvantages_
- The encrypted credentials are the ploperations forge user account. Anybody with commit access could, in principle, add a shell script that would capture or display those credentials and would then have the ability to change our other modules. I'm not worried about @igalic, but it effectively significantly raises the barrier to giving other contributors commit access because it amounts to giving them publish access to all of our forge modules. Note that the credentials are _not_ available during PRs, so that's not impacted.
- This is all a bit hacky:
  - We have a python script somebody else wrote that coordinates between jenkins build jobs to make sure that only one (the "leader") actually publishes and only if the others succeed. That's to work around https://github.com/travis-ci/travis-ci/issues/929. 
  - There's a shell script to do conditional checks about whether to deploy, and to manage it. I'm not sure of a better way to do that. I originally had all that logic in the .travis.yml file itself and that was even worse. I suspect this process would be pretty annoying for anybody other than me to troubleshoot.
- We lose the ability to do expected failed builds, because the python script isn't smart enough to differentiate between expected failed builds and unexpected ones, so it won't ever deploy if we have expected failed builds. This means we have to get rid of the STRICT_VARIABLES=yes check that currently fails.

I believe that this is a workable approach, but may not be worth the tradeoffs. The other option is to stand up a Jenkins (or other) CI server. Using defaults it would have many of the same problems, but we'd have more flexibility to work around them compared to using Travis.

My tentative suggestion is that we do this as an interim measure until I get around to standing up a real CI infrastructure for this project, at which point we'll run beaker tests from it and will want to switch over anyway. I'm totally open to not doing it this way; I just want to get a new release up somehow.
