### PR TITLE
Remove incorrect jfryman/nginx version dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -37,8 +37,7 @@
       "version_requirement": ">= 2.1.0"
     },
     {
-      "name": "jfryman/nginx",
-      "version_requirement": "<= 0.0.10"
+      "name": "jfryman/nginx"
     },
     {
       "name": "danieldreier/thin"


### PR DESCRIPTION
I'm not sure how this got in there, but depending on <= 0.0.10 of jfryman/nginx is definitely not correct. Since he went ahead and removed module_data, I think we can safely depend on the latest forge release.
