### PR TITLE
Fix ca_crl.pem path on unicorn

### DIFF
--- a/manifests/server/unicorn.pp
+++ b/manifests/server/unicorn.pp
@@ -41,7 +41,7 @@ class puppet::server::unicorn {
     ssl_protocols        => $::puppet::server::ssl_protocols,
     use_default_location => false,
     vhost_cfg_append     => {
-      ssl_crl                => "${::puppet::ssldir}/crl.pem",
+      ssl_crl                => "${::puppet::ssldir}/ca/ca_crl.pem",
       ssl_client_certificate => "${::puppet::ssldir}/certs/ca.pem",
       ssl_verify_client      => 'optional',
       proxy_set_header       => [ 'Host $host',


### PR DESCRIPTION
I'm not sure whether this changed in a recent puppet version, but I just ran into an error because the ca_crl.pem file wasn't being created where puppet-puppet expected it. I believe this is correct now because it's the same as the [identical passenger setting](https://github.com/puppetlabs-operations/puppet-puppet/blob/774847f5a7ffb0987d6ce65638f0810d93cb4a72/manifests/passenger.pp#L55). (should probably move that to params.pp since it's the same)
