### PR TITLE
Remove 'puppet::agent' include from package

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -1,6 +1,5 @@
 class puppet::package {
 
-  include puppet::agent
   include puppet::params
 
   if $puppet::agent::manage_repos {

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -4,7 +4,6 @@ shared_examples_for "all puppet master types" do
   it { should compile.with_all_deps }
   it { should contain_class('puppet::server') }
   it { should contain_class('puppet::package') }
-  it { should contain_class('puppet::agent') }
   it { should contain_class('puppet::params') }
   it { should contain_class('puppet::server::config') }
 end


### PR DESCRIPTION
This fixes a problem where puppet::agent cannot manage the agent on a server also using puppet::server without this change, managing the agent via puppet-puppet on a node also using puppet::server results in a duplicate resource declaration

without this puppet::agent is effectively only usable as an include and cannot be used parameterized on the puppet master node

(is that really the case? It seems like somebody should have run into this)
