### PR TITLE
Add future parser support on puppet::agent

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -51,6 +51,7 @@ class puppet::agent(
   $gentoo_keywords   = $puppet::params::agent_keywords,
   $manage_package    = true,
   $stringify_facts   = $puppet::server::stringify_facts,
+  $parser            = undef,
 ) inherits puppet::params {
 
   include puppet

--- a/manifests/agent/config.pp
+++ b/manifests/agent/config.pp
@@ -111,4 +111,12 @@ class puppet::agent::config {
       section => 'main',
       value   => $puppet::agent::stringify_facts;
   }
+
+  if puppet::agent::parser {
+    ini_setting { 'agent_parser':
+      section => 'agent',
+      setting => 'parser',
+      value   => $puppet::agent::parser,
+    }
+  }
 }


### PR DESCRIPTION
Documentation aside, future parser appears to need agent-side enabling based on my experiments using puppetdbquery / puppet-kick. This defaults to current parser, so no behavior will change.
