### PR TITLE
Set default puppet::server::servername to fqdn

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -48,7 +48,7 @@ class puppet::server (
   $reportfrom         = undef,
   $reports            = ['store', 'https'],
   $reporturl          = "https://${::fqdn}/reports",
-  $servername         = undef,
+  $servername         = $::fqdn,
   $serverssl_ciphers  = undef,
   $serverssl_protos   = undef,
   $servertype         = 'unicorn',


### PR DESCRIPTION
Without servername set, the apache configuration file will point to an invalid filename, so this creates a working default setting. 

For example, without this you get errors like:

``` shell
Error: /Stage[main]/Apache::Service/Service[httpd]/ensure: change from stopped to running failed: Could not start Service[httpd]: Execution of '/etc/init.d/apache2 start' retur
ned 1: Starting web server: apache2Syntax error on line 28 of /etc/apache2/sites-enabled/10-puppetmaster.conf:
SSLCertificateFile: file '/var/lib/puppet/ssl/certs/.pem' does not exist or is empty
```
