### PR TITLE
Simplify params.pp

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,138 +3,125 @@ class puppet::params {
 
   case $::operatingsystem {
     'debian', 'ubuntu': {
-      $puppet_cmd         = '/usr/bin/puppet'
-      $agent_package      = 'puppet'
-      $agent_service      = 'puppet'
-      $agent_service_conf = '/etc/default/puppet'
-      $master_package     = 'puppetmaster'
-      $master_service     = 'puppetmaster'
-      $puppet_conf        = '/etc/puppet/puppet.conf'
-      $puppet_confdir     = '/etc/puppet'
-      $puppet_logdir      = '/var/log/puppet'
-      $puppet_vardir      = '/var/lib/puppet'
-      $puppet_ssldir      = '/var/lib/puppet/ssl'
-      $puppet_rundir      = '/var/run/puppet'
-      $default_method     = 'cron'
+      $os_specific = {
+        # placeholder
+      }
     }
     'freebsd': {
-      $puppet_cmd         = '/usr/local/bin/puppet'
-      $agent_package      = 'puppet'
-      $agent_service      = 'puppet'
-      $master_package     = 'puppet'
-      $master_service     = 'puppetmaster'
-      $puppet_conf        = '/usr/local/etc/puppet/puppet.conf'
-      $puppet_confdir     = '/usr/local/etc/puppet'
-      $puppet_logdir      = '/var/log/puppet'
-      $puppet_vardir      = '/var/puppet'
-      $puppet_ssldir      = '/var/puppet/ssl'
-      $puppet_rundir      = '/var/run/puppet'
-      $default_method     = 'cron'
+      $os_specific = {
+        puppet_cmd     => '/usr/local/bin/puppet',
+        master_package => 'puppet',
+        puppet_conf    => '/usr/local/etc/puppet/puppet.conf',
+        puppet_confdir => '/usr/local/etc/puppet',
+        puppet_logdir  => '/var/log/puppet',
+        puppet_vardir  => '/var/puppet',
+        puppet_ssldir  => '/var/puppet/ssl',
+      }
     }
     'darwin': {
-      $puppet_cmd     = '/opt/local/bin/puppet'
-      $agent_package  = 'puppet'
-      $agent_service  = 'com.puppetlabs.puppet'
-      $master_package = ''
-      $master_service = ''
-      $puppet_conf    = '/etc/puppet/puppet.conf'
-      $puppet_confdir = '/etc/puppet'
-      $puppet_logdir  = '/var/log/puppet'
-      $puppet_vardir  = '/var/lib/puppet'
-      $puppet_ssldir  = '/etc/puppet/ssl'
-      $puppet_rundir  = '/var/run'
-      $default_method = 'cron'
+      $os_specific = {
+        puppet_cmd     => '/opt/local/bin/puppet',
+        agent_service  => 'com.puppetlabs.puppet',
+        master_package => '',
+        master_service => '',
+        puppet_ssldir  => '/etc/puppet/ssl',
+      }
     }
     'centos', 'redhat', 'fedora', 'sles', 'opensuse', 'OracleLinux': {
-      $puppet_cmd         = '/usr/bin/puppet'
-      $agent_package      = 'puppet'
-      $agent_service      = 'puppet'
-      $agent_service_conf = '/etc/sysconfig/puppet'
-      $master_package     = 'puppet-server'
-      $master_service     = 'puppetmaster'
-      $puppet_conf        = '/etc/puppet/puppet.conf'
-      $puppet_confdir     = '/etc/puppet'
-      $puppet_logdir      = '/var/log/puppet'
-      $puppet_vardir      = '/var/lib/puppet'
-      $puppet_ssldir      = '/var/lib/puppet/ssl'
-      $puppet_rundir      = '/var/run/puppet'
-      $default_method     = 'cron'
+      $os_specific = {
+        agent_service_conf => '/etc/sysconfig/puppet',
+        master_package     => 'puppet-server',
+      }
     }
     'gentoo': {
-      $puppet_cmd         = '/usr/bin/puppet'
-      $agent_package      = 'app-admin/puppet'
-      $agent_service      = 'puppet'
-      $agent_use          = ['minimal']
-      $master_package     = 'app-admin/puppet'
-      $master_service     = 'puppetmaster'
-      $master_use         = ['-minimal']
-      $puppet_conf        = '/etc/puppet/puppet.conf'
-      $puppet_confdir     = '/etc/puppet'
-      $puppet_logdir      = '/var/log/puppet'
-      $puppet_vardir      = '/var/lib/puppet'
-      $puppet_ssldir      = '/var/lib/puppet/ssl'
-      $puppet_rundir      = '/var/run/puppet'
-      $default_method     = 'cron'
+      $os_specific = {
+        agent_package  => 'app-admin/puppet',
+        agent_use      => ['minimal'],
+        master_package => 'app-admin/puppet',
+        master_use     => ['-minimal'],
+      }
     }
     'openbsd': {
-      $puppet_cmd         = '/usr/local/bin/puppet'
-      $agent_package      = 'puppet'
-      $agent_service      = 'puppetd'
-      $master_package     = 'puppet'
-      $master_service     = 'puppetmasterd'
-      $puppet_conf        = '/etc/puppet/puppet.conf'
-      $puppet_confdir     = '/etc/puppet'
-      $puppet_logdir      = '/var/puppet/log'
-      $puppet_vardir      = '/var/puppet'
-      $puppet_ssldir      = '/etc/puppet/ssl'
-      $puppet_rundir      = '/var/puppet/run'
-      $default_method     = 'service'
+      $os_specific = {
+        puppet_cmd     => '/usr/local/bin/puppet',
+        agent_service  => 'puppetd',
+        master_package => 'puppet',
+        master_service => 'puppetmasterd',
+        puppet_logdir  => '/var/puppet/log',
+        puppet_vardir  => '/var/puppet',
+        puppet_ssldir  => '/etc/puppet/ssl',
+        puppet_rundir  => '/var/puppet/run',
+        default_method => 'service',
+        puppet_user    => '_puppet',
+        puppet_group   => '_puppet',
+      }
     }
     # This stops the puppet class breaking. But really, we only have very
     # limited support for Solaris. And only through OpenCSW
     # Taken from: '/opt/csw/bin/puppet config print ...'
     'solaris','sunos': {
-      $puppet_cmd         = '/opt/csw/bin/puppet'
-      $puppet_conf        = '/etc/puppet/puppet.conf'
-      $puppet_confdir     = '/etc/puppet'
-      $puppet_logdir      = '/var/log/puppet'
-      $puppet_vardir      = '/var/lib/puppet'
-      $puppet_ssldir      = '/etc/puppet/ssl'
-      $puppet_rundir      = '/var/lib/puppet/run/'
-      $agent_service      = 'svc:/network/cswpuppetd'
-      $default_method     = 'cron'
+      $os_specific = {
+        puppet_cmd     => '/opt/csw/bin/puppet',
+        puppet_ssldir  => '/etc/puppet/ssl',
+        puppet_rundir  => '/var/lib/puppet/run/',
+        agent_service  => 'svc:/network/cswpuppetd',
+      }
     }
     'windows': {
-      $puppet_cmd         = 'C:/Program Files (x86)/Puppet Labs/Puppet/bin/puppet.bat'
-      $agent_package      = 'Puppet'
-      $agent_service      = 'puppet'
-      # I don't think these are applicable to Windows
-      # $agent_service_conf = '/etc/default/puppet'
-      # $master_package     = 'puppetmaster'
-      # $master_service     = 'puppetmaster'
-
-      # Note this is only going to work for 2008 and later
-      # The correct value is %APPDATA% (or something similar)
-      $puppet_conf        = 'C:/ProgramData/PuppetLabs/puppet/etc/puppet.conf'
-      $puppet_confdir     = 'C:/ProgramData/PuppetLabs/puppet/etc'
-      $puppet_logdir      = 'C:/ProgramData/PuppetLabs/puppet/var/log'
-      $puppet_vardir      = 'C:/ProgramData/PuppetLabs/puppet/var'
-      $puppet_ssldir      = 'C:/ProgramData/PuppetLabs/puppet/etc/ssl'
-      $puppet_rundir      = 'C:/ProgramData/PuppetLabs/puppet/var/run'
-      $default_method     = 'only_service'
+      $os_specific = {
+        puppet_cmd     => 'C:/Program Files (x86)/Puppet Labs/Puppet/bin/puppet.bat',
+        agent_package  => 'Puppet',
+        # Note this is only going to work for 2008 and later
+        # The correct value is %APPDATA% (or something similar)
+        puppet_conf    => 'C:/ProgramData/PuppetLabs/puppet/etc/puppet.conf',
+        puppet_confdir => 'C:/ProgramData/PuppetLabs/puppet/etc',
+        puppet_logdir  => 'C:/ProgramData/PuppetLabs/puppet/var/log',
+        puppet_vardir  => 'C:/ProgramData/PuppetLabs/puppet/var',
+        puppet_ssldir  => 'C:/ProgramData/PuppetLabs/puppet/etc/ssl',
+        puppet_rundir  => 'C:/ProgramData/PuppetLabs/puppet/var/run',
+        default_method => 'only_service',
+      }
     }
     default: { fail("Sorry, ${::operatingsystem} is not supported") }
   }
 
-  $puppet_user = $::osfamily ? {
-    'OpenBSD' => '_puppet',
-    default   => 'puppet',
+  $default_value = {
+    agent_package      => 'puppet',
+    agent_service      => 'puppet',
+    agent_service_conf => '/etc/default/puppet',
+    default_method     => 'cron',
+    master_package     => 'puppetmaster',
+    master_service     => 'puppetmaster',
+    puppet_cmd         => '/usr/bin/puppet',
+    puppet_conf        => '/etc/puppet/puppet.conf',
+    puppet_confdir     => '/etc/puppet',
+    puppet_logdir      => '/var/log/puppet',
+    puppet_rundir      => '/var/run/puppet',
+    puppet_ssldir      => '/var/lib/puppet/ssl',
+    puppet_user        => 'puppet',
+    puppet_group       => 'puppet',
+    puppet_vardir      => '/var/lib/puppet',
+    report_dir         => '/usr/lib/ruby/vendor_ruby/puppet/reports',
   }
 
-  $puppet_group = $::osfamily ? {
-    'OpenBSD' => '_puppet',
-    default   => 'puppet',
-  }
+  $merged_values = merge($default_value, $os_specific)
 
-  $report_dir = '/usr/lib/ruby/vendor_ruby/puppet/reports'
+  $agent_package      = $merged_values[agent_package]
+  $agent_service      = $merged_values[agent_service]
+  $agent_service_conf = $merged_values[agent_service_conf]
+  $agent_use          = $merged_values[agent_use]
+  $default_method     = $merged_values[default_method]
+  $master_package     = $merged_values[master_package]
+  $master_service     = $merged_values[master_service]
+  $master_use         = $merged_values[master_use]
+  $puppet_cmd         = $merged_values[puppet_cmd]
+  $puppet_conf        = $merged_values[puppet_conf]
+  $puppet_confdir     = $merged_values[puppet_confdir]
+  $puppet_group       = $merged_values[puppet_group]
+  $puppet_logdir      = $merged_values[puppet_logdir]
+  $puppet_rundir      = $merged_values[puppet_rundir]
+  $puppet_ssldir      = $merged_values[puppet_ssldir]
+  $puppet_user        = $merged_values[puppet_user]
+  $puppet_vardir      = $merged_values[puppet_vardir]
+
 }


### PR DESCRIPTION
This uses the stdlib merge function to merge hashes so that we don't have to redeclare the same values for each OS when there are common defaults.

I'm not committed to doing things this way, but was inspired by a similar (albeit slightly more complex) approach in jfryman/nginx to solve the same problem.