### PR TITLE
Add option to provide puppet agent install script

### DIFF
--- a/manifests/deploy.pp
+++ b/manifests/deploy.pp
@@ -1,0 +1,24 @@
+# Class: puppet::deploy
+#
+# This class installs and configures parameters for a curl|bash
+# puppet install / deploy script
+#
+# Once this is installed, you can connect new nodes to the master using:
+# curl https://puppetmaster.example.com/deploy | sudo bash
+#
+# (and then signing the cert on the master)
+#
+class puppet::deploy {
+  # Use the puppet_install module to install a puppet deploy script that agents
+  # can be installed with via a curl | bash command
+  if $::puppet::webserver == 'webrick' {
+    fail('puppet::deploy requires nginx or apache; standalone not supported')
+  }
+  class {'::puppet_installer':
+    master    => $::fqdn,
+    webserver => $::puppet::server::webserver,
+    www_root  => $::puppet::params::puppet_confdir,
+    ssl_cert  => "${::puppet::ssldir}/certs/${::fqdn}.pem",
+    ssl_key   => "${::puppet::ssldir}/private_keys/${::fqdn}.pem",
+  }
+}

--- a/metadata.json
+++ b/metadata.json
@@ -45,6 +45,10 @@
     {
       "name": "puppetlabs/puppetdb",
       "version_requirement": ">= 4.1.0"
+    },
+    {
+      "name": "danieldreier/puppet_installer",
+      "version_requirement": ">= 0.1.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
This is a bit experimental, and I'd like feedback on whether this feels like something in-scope for this module.

This wraps another module ([danieldreier/puppet_installer](https://forge.puppetlabs.com/danieldreier/puppet_installer) that I just published which installs a bash-language puppet install script and creates an apache or nginx vhost to provide it to new client nodes.

The intended use case is that when you add a new node to your infrastructure, you can do something like the following to install puppet and connect it to your master:

``` bash
curl https://puppetmaster.example.com/deploy | sudo bash
```

The reason it's convenient to do it from inside the puppet-puppet module is that it simplifies the process of bootstrapping an entirely new infrastructure. The downside is that many of the options (using your own purchased SSL cert that isn't the puppet master's) are blocked unless you use hiera automatic parameter substitution.

Please push back on including this if it feels like unwarranted scope creep. I'm not quite sure where to draw the line in terms of whether this module is purely about puppetizing the puppet master itself vs a more opinionated puppetizing of the puppet infrastructure. If people would rather keep this more narrowly defined we could create an additional module to hold the opinionated stuff and just wrap this.
