### PR TITLE
Refactor rspec-puppet tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ group :test do
   gem "puppet-syntax"
   gem "puppetlabs_spec_helper"
   gem "metadata-json-lint"
-  gem "puppet_spec_facts", '>= 0.2.0'
+  gem "puppet_spec_facts", '>= 0.2.1'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ group :test do
   gem "puppet-syntax"
   gem "puppetlabs_spec_helper"
   gem "metadata-json-lint"
+  gem "puppet_spec_facts", '>= 0.2.0'
 end
 
 group :development do

--- a/spec/classes/agent_spec.rb
+++ b/spec/classes/agent_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 shared_examples 'agent examples' do
-  it { should contain_class('puppet::package') }
   it { should contain_class('puppet::agent') }
   it { should compile.with_all_deps }
   it { should contain_ini_setting('report_server').with_value('puppet_reports.example.com') }
@@ -10,97 +9,79 @@ shared_examples 'agent examples' do
   it { should contain_package('puppet') }
 end
 
-describe 'puppet::agent' do
-  describe "sample agent configuration from documentation" do
-    let(:params) {{
-      :server        => 'puppet.example.com',
-      :report_server => 'puppet_reports.example.com',
-      :method        => 'service',
-    }}
-    context 'CentOS, RedHat, Debian, Ubuntu' do
-      ['RedHat', 'CentOS', 'Debian', 'Ubuntu'].each do |operatingsystem|
+PuppetSpecFacts.facts_for_platform_by_name(["Debian_wheezy_7.7_amd64_3.7.2_structured", "CentOS_5.11_x86_64_3.7.1_structured", "FreeBSD_10.0-RELEASE_amd64_3.6.2_structured"]).each do |name, facthash|
+describe "puppet::agent" do
+    let(:facts) { facthash }
 
-        osfamily   = 'Redhat'  if ['RedHat', 'CentOS'].include? operatingsystem
-        osfamily ||= 'Debian'
+    context "running on #{name}" do
+      [true, false].each do |manage_repos|
 
-        let(:facts) {{
-          :osfamily        => osfamily,
-          :operatingsystem => operatingsystem,
-          :lsbdistid       => operatingsystem,
-          :lsbdistcodename => 'lolwut'
-        }}
-        context 'running as service' do
+        context "when manage_repos => #{manage_repos}" do
           let(:params) {{
             :server        => 'puppet.example.com',
             :report_server => 'puppet_reports.example.com',
-            :method        => 'service',
+            :manage_repos  => manage_repos,
           }}
-          it_behaves_like "agent examples"
-          it do
-            should contain_service('puppet_agent').with({
-              :ensure => "running"
-            })
-            should contain_cron('puppet agent')
-          end
-        end
-        context 'method => "only_service"' do
-          let(:params) {{
-            :server        => 'puppet.example.com',
-            :report_server => 'puppet_reports.example.com',
-            :method        => 'only_service',
-          }}
-          it_behaves_like "agent examples"
-          it do
-            should contain_service('puppet_agent').with({
-              :ensure => "running"
-            })
-            should_not contain_cron('puppet agent')
-          end
-        end
-        context 'method => "none"' do
-          let(:params) {{
-            :server        => 'puppet.example.com',
-            :report_server => 'puppet_reports.example.com',
-            :method        => 'only_service',
-          }}
-          it_behaves_like "agent examples"
-          it do
-            should contain_service('puppet_agent').with({
-              :ensure => "running"
-            })
-            should_not contain_cron('puppet agent')
-          end
-        end
-        context 'method => "cron"' do
-          let(:params) {{
-            :server        => 'puppet.example.com',
-            :report_server => 'puppet_reports.example.com',
-            :method        => 'cron',
-          }}
-          it_behaves_like "agent examples"
-          it do
-            should_not contain_service('puppet_agent').with({
-              :ensure => "running"
-            })
-            should contain_cron('puppet agent').with_command(/puppet agent/)
-          end
-        end
-        context 'manage_repos => false' do
-          let(:params) {{
-            :server        => 'puppet.example.com',
-            :report_server => 'puppet_reports.example.com',
-            :manage_repos  => false,
-          }}
-          it_behaves_like "agent examples"
-          it do
-            should contain_service('puppet_agent')
-            should contain_cron('puppet agent').with_command(/puppet agent/)
-            should_not contain_yumrepo('puppetlabs-products')
-            should_not contain_apt__source('puppetlabs')
-          end
-        end
 
+          case facthash['osfamily']
+          when 'RedHat'
+            it_behaves_like "agent examples"
+            it {
+              is_expected.to contain_class('Puppet::Package::Repository') if manage_repos == true
+              is_expected.to contain_yumrepo('puppetlabs-products') if manage_repos == true
+              is_expected.to_not contain_yumrepo('puppetlabs-products') if manage_repos == false
+              is_expected.to_not contain_apt__source('puppetlabs')
+            }
+          when 'Debian'
+            it_behaves_like "agent examples"
+            it { is_expected.to contain_class('Puppet::Package::Repository') if manage_repos == true }
+            it { should_not contain_class('puppetlabs_yum') }
+            if manage_repos == true
+            it {
+              is_expected.to contain_class('puppetlabs_apt')
+              is_expected.to contain_apt__source('puppetlabs')
+            }
+            elsif manage_repos == false
+              it { is_expected.to_not contain_class('puppetlabs_apt') }
+            end
+          when 'FreeBSD'
+            if manage_repos == false
+              it {
+                is_expected.to_not contain_class('puppetlabs_apt')
+                is_expected.to_not contain_class('puppetlabs_yum')
+                is_expected.to compile.with_all_deps
+              }
+            end
+          end
+        end
+      end
+      ['service','cron','only_service'].each do |agent_method|
+        manage_repos = false if facthash['osfamily'] == 'FreeBSD'
+        context "method => #{agent_method}" do
+          describe "agent configuration on #{facthash["osfamily"]}" do
+            let(:params) {{
+              :server        => 'puppet.example.com',
+              :report_server => 'puppet_reports.example.com',
+              :method        => agent_method,
+              :manage_repos  => manage_repos,
+            }}
+
+            it_behaves_like "agent examples"
+            case agent_method
+            when 'service'
+              it { should contain_service('puppet_agent').with({ :ensure => "running" }) }
+              it { should contain_cron('puppet agent') }
+            when 'cron'
+              it { should contain_service('puppet_agent').with({ :ensure => "stopped" }) }
+              it { should contain_cron('puppet agent') }
+            when 'only_service'
+              it { should contain_service('puppet_agent').with({ :ensure => "running" }) }
+              it { should_not contain_cron('puppet agent') }
+            end
+          end
+        end
       end
     end
   end
 end
+

--- a/spec/classes/puppet_spec.rb
+++ b/spec/classes/puppet_spec.rb
@@ -1,28 +1,31 @@
 require 'spec_helper'
 
-describe 'puppet' do
-  context 'supported operating systems' do
-    ['Debian', 'RedHat', 'CentOS'].each do |operatingsystem|
-      describe "puppet class without any parameters on #{operatingsystem}" do
-        let(:params) {{ }}
-        let(:facts) {{
-          :operatingsystem => operatingsystem,
-        }}
+PuppetSpecFacts.facts_for_platform_by_name([
+  "Debian_wheezy_7.7_amd64_3.7.2_structured",
+  "Ubuntu_precise_12.04_amd64_PE-3.3.2_stringified",
+  "Ubuntu_trusty_14.04_amd64_PE-3.3.2_stringified"]).each do |name, facthash|
 
-        it { should compile.with_all_deps }
+  describe 'puppet' do
+    context 'supported operating systems' do
+      ['Debian', 'RedHat', 'CentOS'].each do |operatingsystem|
+        describe "puppet class without any parameters on #{operatingsystem}" do
+          let(:params) {{ }}
+          let(:facts) { facthash }
 
-        it { should contain_class('puppet::params') }
+          it { should compile.with_all_deps }
+          it { should contain_class('puppet::params') }
+        end
       end
     end
-  end
 
-  context 'unsupported operating system' do
-    describe 'puppet class without any parameters on OpenVMS' do
-      let(:facts) {{
-        :operatingsystem => 'OpenVMS',
-      }}
+    context 'unsupported operating system' do
+      describe 'puppet class without any parameters on OpenVMS' do
+        let(:facts) {{
+          :operatingsystem => 'OpenVMS',
+        }}
 
-      it { expect { should contain_package('puppet') }.to raise_error(Puppet::Error, /Sorry, OpenVMS is not supported/) }
+        it { expect { should contain_package('puppet') }.to raise_error(Puppet::Error, /Sorry, OpenVMS is not supported/) }
+      end
     end
   end
 end

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -20,183 +20,66 @@ shared_examples_for "basic puppetmaster environment config" do
   it { should contain_ini_setting('modulepath').with_ensure('absent') }
 end
 
-describe 'puppet::server' do
-  describe "webrick puppet::server" do
-    let(:params) {{
-      :servertype      => 'standalone',
-      :manifest        => '/etc/puppet/manifests/site.pp',
-      :modulepath      => ['/etc/puppet/environments/production/modules'],
-      :environmentpath => '$confdir/environments',
-      :ca              => true,
-    }}
-    shared_examples_for "all standalone masters" do
-      it { should contain_class('puppet::server::standalone') }
-    end
+PuppetSpecFacts.facts_for_platform_by_name(["Debian_wheezy_7.7_amd64_3.7.2_structured", "Ubuntu_precise_12.04_amd64_PE-3.3.2_stringified", "Ubuntu_trusty_14.04_amd64_PE-3.3.2_stringified"]).each do |name, facthash|
+describe "puppet::server" do
+    let(:facts) { facthash }
 
-    context 'RedHat-derived Distros' do
-      ['RedHat', 'CentOS'].each do |operatingsystem|
-        context "#{operatingsystem}" do
-          let(:facts) {{
-            :osfamily        => 'redhat',
-            :operatingsystem => operatingsystem,
+    context "running on #{name}" do
+      ['standalone','passenger','unicorn','thin'].each do |server_type|
+#        manage_repos = false if facthash['osfamily'] == 'FreeBSD'
+        context "servertype => #{server_type}" do
+          let(:params) {{
+            :servertype   => server_type,
+            :storeconfigs => 'puppetdb',
+            :manifest     => '/etc/puppet/manifests/site.pp',
+            :modulepath   => ['/etc/puppet/environments/production/modules'],
+            :environmentpath => '$confdir/environments',
+            :ca           => true,
           }}
 
+          case facthash['osfamily']
+          when 'RedHat'
+            puppetmaster_package = 'puppet-server'
+          when 'Debian'
+            puppetmaster_package = 'puppetmaster'
+
+          end
           it_behaves_like "all puppet master types"
-          it_behaves_like "all standalone masters"
           it_behaves_like "basic puppetmaster environment config"
 
-          # RHEL-specific examples
-          it { should contain_package('puppet-server') }
-          it do
-            should contain_service('puppetmaster').with({
-              :ensure => "running"
-            })
+          #it_behaves_like "agent examples"
+          case server_type
+            when 'standalone'
+            it {
+              should contain_class('puppet::server::standalone')
+              should contain_service('puppetmaster').with({ :ensure => "running" })
+              should contain_package(puppetmaster_package)
+            }
+
+            when 'passenger'
+              it {
+                should contain_class('puppet::server::passenger')
+                should contain_class('apache')
+                should contain_class('apache::mod::passenger')
+              }
+
+            when 'unicorn'
+              it {
+                should contain_class('puppet::server::unicorn')
+                should contain_service('puppetmaster').with({:ensure => "stopped"})
+                should contain_service('nginx').with({:ensure => "running"})
+                should contain_service('unicorn_puppetmaster').with({:ensure => "running"})
+              }
+            when 'thin'
+              it {
+                should contain_class('puppet::server::thin')
+                should contain_service('puppetmaster').with({ :ensure => "stopped" })
+                should contain_service('nginx').with({:ensure => "running"})
+                should contain_service('thin-puppetmaster').with({:ensure => "running"})
+                should contain_file('/etc/thin.d/puppetmaster.yml')
+              }
           end
         end
-      end
-    end
-
-    context 'Debian-derived distros' do
-      ['Debian','Ubuntu'].each do |operatingsystem|
-        context "#{operatingsystem}" do
-          let(:facts) {{
-            :operatingsystem => operatingsystem,
-            :osfamily        => 'debian',
-            :lsbdistid       => operatingsystem,
-            :lsbdistcodename => 'lolwut',
-          }}
-
-          it_behaves_like "all puppet master types"
-          it_behaves_like "all standalone masters"
-          it_behaves_like "basic puppetmaster environment config"
-
-          # Debian-specific examples
-          it { should contain_package('puppetmaster') }
-          it do
-            should contain_service('puppetmaster').with({
-              :ensure => "running"
-            })
-          end
-        end
-      end
-    end
-  end
-  describe "passenger puppet::server" do
-    let(:params) {{
-      :servertype   => 'passenger',
-      :storeconfigs => 'puppetdb',
-      :manifest     => '/etc/puppet/manifests/site.pp',
-      :modulepath   => ['/etc/puppet/environments/production/modules'],
-      :ca           => true,
-    }}
-    context 'CentOS/RedHat' do
-      ['RedHat', 'CentOS'].each do |operatingsystem|
-        let(:facts) {{
-          :operatingsystem => operatingsystem,
-          :operatingsystemrelease => '6',
-          :osfamily => 'redhat',
-          :puppetversion => '3.4.2',
-          :concat_basedir => '/foo'
-        }}
-        it_behaves_like "all puppet master types"
-        it_behaves_like "basic puppetmaster config"
-
-        # Tests specific to passenger server
-        it { should contain_class('puppet::server::passenger') }
-        it { should contain_class('apache') }
-        it { should contain_class('apache::mod::passenger') }
-
-        # RHEL-family specific examples
-        it { should contain_package('puppet-server') }
-        it do
-          should contain_service('httpd').with({
-            :ensure => "running"
-          })
-          should contain_service('puppetmaster').with({
-            :ensure => "stopped"
-          })
-        end
-      end
-    end
-  end
-  describe "unicorn puppet::server" do
-    let(:params) {{
-      :servertype   => 'unicorn',
-      :storeconfigs => 'puppetdb',
-      :manifest     => '/etc/puppet/manifests/site.pp',
-      :modulepath   => ['/etc/puppet/environments/production/modules'],
-      :ca           => true,
-    }}
-    context 'Debian' do
-      let(:facts) {{
-        :operatingsystem        => 'debian',
-        :operatingsystemrelease => '7',
-        :osfamily               => 'debian',
-        :puppetversion          => '3.4.2',
-        :concat_basedir         => '/foo',
-        :kernel                 => 'linux',
-        :lsbdistid              => 'debian',
-        :lsbdistcodename        => 'wheezy',
-      }}
-      it_behaves_like "all puppet master types"
-      it_behaves_like "basic puppetmaster config"
-
-      it { should contain_package('puppetmaster') }
-
-      # Tests specific to passenger server
-      it { should contain_class('puppet::server::unicorn') }
-
-      it do
-        should contain_service('puppetmaster').with({
-          :ensure => "stopped"
-        })
-        should contain_service('nginx').with({
-          :ensure => "running"
-        })
-        should contain_service('unicorn_puppetmaster').with({
-          :ensure => "running"
-        })
-      end
-    end
-  end
-  describe "thin puppet::server" do
-    let(:params) {{
-      :servertype   => 'thin',
-      :storeconfigs => 'puppetdb',
-      :manifest     => '/etc/puppet/manifests/site.pp',
-      :modulepath   => ['/etc/puppet/environments/production/modules'],
-      :ca           => true,
-    }}
-    context 'Debian' do
-      let(:facts) {{
-        :operatingsystem        => 'debian',
-        :operatingsystemrelease => '7',
-        :osfamily               => 'debian',
-        :puppetversion          => '3.4.2',
-        :concat_basedir         => '/foo',
-        :kernel                 => 'linux',
-        :lsbdistid              => 'debian',
-        :lsbdistcodename        => 'wheezy',
-      }}
-      it_behaves_like "all puppet master types"
-      it_behaves_like "basic puppetmaster config"
-
-      it { should contain_package('puppetmaster') }
-
-      # Tests specific to passenger server
-      it { should contain_class('puppet::server::thin') }
-
-      it do
-        should contain_service('puppetmaster').with({
-          :ensure => "stopped"
-        })
-        should contain_service('nginx').with({
-          :ensure => "running"
-        })
-        should contain_service('thin-puppetmaster').with({
-          :ensure => "running"
-        })
-        should contain_file('/etc/thin.d/puppetmaster.yml')
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,1 +1,3 @@
+require 'puppet_spec_facts'
+include PuppetSpecFacts
 require 'puppetlabs_spec_helper/module_spec_helper'


### PR DESCRIPTION
I've refactored the rspec-puppet tests because seeing PR https://github.com/puppetlabs-operations/puppet-puppet/pull/147 languish with good code and a very modestly broken test indicates to me that the current tests are too hard to understand. They were very heavily copy-pasted.

This is also the first production use of the [puppet_spec_facts](https://github.com/danieldreier/puppet_spec_facts) gem that I recently wrote; it contains facter fact hashes and allows you to iterate over them so that you don't have to have that logic and data making a mess of the spec file.

The nutshell version of the changes is replacing copy-paste duplication with iteration and variables. Glad to take a different approach or make changes to puppet_spec_facts if needed.