### PR TITLE
Revert "update cron interval"

### DIFF
--- a/manifests/agent/cron.pp
+++ b/manifests/agent/cron.pp
@@ -1,6 +1,7 @@
 class puppet::agent::cron (
   $enable   = true,
   $run_noop = false,
+  $interval = 3,
 ) {
   include puppet::params
 
@@ -19,6 +20,6 @@ class puppet::agent::cron (
   cron { 'puppet agent':
     ensure  => $ensure,
     command => $cmd,
-    minute  => fqdn_rand(60),
+    minute  => interval($interval, 60),
   }
 }


### PR DESCRIPTION
This reverts commit 7eda4b4eb0c848579940fc205a5c6143a90db43a.
The reverted commit replaced interval() with fqdn_rand(), for no clear reason.
The former function though returns a list of random numbers, so we can have
agent runs multiple times per hour. fqdn_rand returns only one number, thus
this functionality was lost.

Conflicts:
	manifests/agent/cron.pp