### PR TITLE
(issue #164) fix metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,48 +3,46 @@
   "version": "0.13.0",
   "source": "https://github.com/puppetlabs-operations/puppet-puppet",
   "author": "Puppet Labs Operations",
-  "license": "Apache 2",
+  "license": "Apache-2.0",
   "summary": "Install and manage Puppet open source",
   "description": "UNKNOWN",
   "project_page": "https://github.com/puppetlabs-operations/puppet-puppet",
   "dependencies": [
     {
       "name": "stahnma/puppetlabs_yum",
-      "version_requirement": ">= 0.1.0"
+      "version_requirement": ">= 0.1.0 <1.0.0"
     },
     {
       "name": "ploperations/puppetlabs_apt",
-      "version_requirement": ">= 0.0.1"
-    },
-    {
-      "name": "ploperations/interval",
-      "version_requirement": ">= 0.0.1"
+      "version_requirement": ">= 0.0.1 <1.0.0"
     },
     {
       "name": "ploperations/unicorn",
-      "version_requirement": ">= 1.0.0"
+      "version_requirement": ">= 1.0.0 <2.0.0"
     },
     {
       "name": "puppetlabs/inifile",
-      "version_requirement": ">= 1.0.0"
+      "version_requirement": ">= 1.0.0 <2.0.0"
     },
     {
       "name": "puppetlabs/apache",
-      "version_requirement": ">= 0.9.0"
+      "version_requirement": ">= 0.9.0 <2.0.0"
     },
     {
       "name": "gentoo/portage",
-      "version_requirement": ">= 2.1.0"
+      "version_requirement": ">= 2.1.0 <3.0.0"
     },
     {
-      "name": "jfryman/nginx"
+      "name": "jfryman/nginx",
+      "version_requirement": ">= 0.2.0 <1.0.0"
     },
     {
-      "name": "danieldreier/thin"
+      "name": "danieldreier/thin",
+      "version_requirement": ">= 0.1.0 <1.0.0"
     },
     {
       "name": "puppetlabs/puppetdb",
-      "version_requirement": ">= 4.1.0"
+      "version_requirement": ">= 4.1.0 <5.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
This removes the dependency on ploperations/interval, because it's no longer used, and resolves open-ended dependencies by restricting them to the current major version. This also changes the license identifier so it can be programatically identified by Puppet Forge.

Without this, we do not conform to the forge recommended style guide. I believe this resolves @igalic's issue https://github.com/puppetlabs-operations/puppet-puppet/issues/164.