### PR TITLE
Restrict metadata-json-lint to version < 0.0.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ group :test do
   gem "rspec", '< 3.0.0'
   gem "puppet-syntax"
   gem "puppetlabs_spec_helper"
-  gem "metadata-json-lint"
+  gem "metadata-json-lint", '<= 0.0.4'
   gem "puppet_spec_facts", '>= 0.2.1'
 end
 


### PR DESCRIPTION
Restrict the metadata-json-lint gem to below 0.0.4 to avoid a conflict between puppet and that gem's conflicting dependencies on a Semantic::Dependency class.

Without this change, puppet-blacksmith and metadata-json-lint conflict due to puppet-blacksmith requiring the puppet gem, which currently conflicts with metadata-json-lint. This prevents rspec tests from running, but only if the metadata-json-lint version is 0.0.5.

The issue is documented at https://github.com/nibalizer/metadata-json-lint/issues/10 and at https://github.com/maestrodev/puppet-blacksmith/issues/14. This is a workaround until the various upstreams get things sorted out.