### PR TITLE
Add support for multiple cron agent runs per hour

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -51,6 +51,7 @@ class puppet::agent(
   $gentoo_keywords   = $puppet::params::agent_keywords,
   $manage_package    = true,
   $stringify_facts   = $puppet::server::stringify_facts,
+  $frequency         = 1,
 ) inherits puppet::params {
 
   include puppet
@@ -76,8 +77,10 @@ class puppet::agent(
 
   case $method {
     cron: {
-      include puppet::agent::cron
       class { 'puppet::agent::service': enable => false }
+      class { 'puppet::agent::cron':
+        frequency => $frequency
+      }
     }
     service: {
       include puppet::agent::service

--- a/manifests/agent/cron.pp
+++ b/manifests/agent/cron.pp
@@ -1,6 +1,7 @@
 class puppet::agent::cron (
-  $enable   = true,
-  $run_noop = false,
+  $enable    = true,
+  $run_noop  = false,
+  $frequency = 1
 ) {
   include puppet::params
 
@@ -16,9 +17,13 @@ class puppet::agent::cron (
     $cmd = "${puppet::params::puppet_cmd} agent --confdir ${puppet::params::puppet_confdir} --onetime --no-daemonize >/dev/null"
   }
 
+  $interval = 60 / $frequency
+  $random_offset = fqdn_rand($interval)
+  $cron_schedule = $frequency.map |$value| { ($value * $interval) + $random_offset}
+
   cron { 'puppet agent':
     ensure  => $ensure,
     command => $cmd,
-    minute  => fqdn_rand(60),
+    minute  => $cron_schedule,
   }
 }

--- a/tests/agent_cron.pp
+++ b/tests/agent_cron.pp
@@ -1,3 +1,4 @@
 class { 'puppet::agent':
-  method => 'cron',
+  method    => 'cron',
+  frequency => 2,
 }


### PR DESCRIPTION
Use map function from future parser to allow cron to run the agent more than once per hour.

This re-implements the functionality requested in PR https://github.com/puppetlabs-operations/puppet-puppet/pull/162, being the ability to run the agent multiple times per hour using cron.

I just hacked this together and wanted to get feedback, both from @tampakrap as to whether it meets his needs, and from other puppet-puppet users because this has a hard dependency on future parser and the compile will fail with current parser. Puppet Forge currently doesn't have a way to indicate a future parser dependency, so we'd need to update the readme with a prominent warning about the future parser dependency.

If this looks like a reasonable approach, I'll write some test coverage, update the readme, and update this PR.