### PR TITLE
(puppet-puppet/#149) fix empty stringify_facts

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -50,7 +50,7 @@ class puppet::agent(
   $gentoo_use        = $puppet::params::agent_use,
   $gentoo_keywords   = $puppet::params::agent_keywords,
   $manage_package    = true,
-  $stringify_facts   = $puppet::server::stringify_facts,
+  $stringify_facts   = false,
 ) inherits puppet::params {
 
   include puppet


### PR DESCRIPTION
Set stringify_facts to default to false on the agent, just like we have it on the master.

This fixes an issue that happens on agent nodes that are not also masters, where the puppet::server::stringify_facts variable was not in scope because puppet::server hadn't been loaded, so it resolved to nil, and the ini setting was then set to an empty string, which puppet cannot parse. This broke puppet runs on impacted agents.

This simply sets it to a string rather than attempting to use the same setting as the master; it should be easy enough to set those the same.

If it's important to people, we can move this to a params setting.

We should add test coverage on this, but since it's [currently breaking puppet runs for people](https://github.com/puppetlabs-operations/puppet-puppet/issues/149) I wanted to get a fix out quickly. If you'd prefer to wait until there's an rspec tests I can add it.