### PR TITLE
Add ability for custom package names

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -51,6 +51,7 @@ class puppet::agent(
   $gentoo_keywords   = $puppet::params::agent_keywords,
   $manage_package    = true,
   $stringify_facts   = false,
+  $package           = $puppet::params::agent_package,
 ) inherits puppet::params {
 
   include puppet

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -1,7 +1,5 @@
 class puppet::package {
 
-  include puppet::params
-
   if $puppet::agent::manage_repos {
     include puppet::package::repository
   }
@@ -10,12 +8,12 @@ class puppet::package {
     include puppet::package::gentoo
   }
 
-  package { $puppet::params::agent_package:
+  package { $puppet::agent::package:
     ensure => $puppet::agent::ensure;
   }
 
-  if $puppet::server::master and ($puppet::params::master_package != $puppet::params::agent_package) {
-    package { $puppet::params::master_package:
+  if $puppet::server::master and ($puppet::server::package != $puppet::agent::package) {
+    package { $puppet::server::package:
       ensure => $puppet::server::ensure;
     }
   }

--- a/manifests/package/gentoo.pp
+++ b/manifests/package/gentoo.pp
@@ -1,16 +1,15 @@
 class puppet::package::gentoo {
 
   include puppet::agent
-  include puppet::params
 
   if $puppet::server::master {
     include puppet::server
     $keywords = $puppet::server::gentoo_keywords
-    $package  = $puppet::params::master_package
+    $package  = $puppet::server::package
     $use      = $puppet::server::gentoo_use
   } else {
     $keywords = $puppet::agent::gentoo_keywords
-    $package  = $puppet::params::agent_package
+    $package  = $puppet::agent::package
     $use      = $puppet::agent::gentoo_use
   }
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -54,6 +54,7 @@ class puppet::server (
   $servertype         = 'unicorn',
   $storeconfigs       = undef,
   $stringify_facts    = false,
+  $package            = $puppet::params::master_package,
 ) inherits puppet::params {
 
   $master = true


### PR DESCRIPTION
Allow overriding the default distro package names by specifying
$puppet::agent::package and $puppet::server::package