### PR TITLE
Disable $puppet::agent::manage_repos by default

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -37,7 +37,7 @@ class puppet::agent (
   $ca_server         = undef,
   $report            = true,
   $report_server     = undef,
-  $manage_repos      = true,
+  $manage_repos      = false,
   $environment       = $::environment,
   $pluginsync        = true,
   $certname          = $::clientcert,


### PR DESCRIPTION
PuppetLabs packages are available for only a subset of distros that this module
is available for, plus people may expect official distro packages to be pulled
in instead of third party ones. Thus it makes more sense to have this off as
default option.