### PR TITLE
Revert PR-166; use newer metadata-json-lint gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ group :test do
   gem "rspec", '< 3.0.0'
   gem "puppet-syntax"
   gem "puppetlabs_spec_helper"
-  gem "metadata-json-lint", '<= 0.0.4'
+  gem "metadata-json-lint"
   gem "puppet_spec_facts", '>= 0.2.1'
 end
 


### PR DESCRIPTION
This reverts [PR-166](https://github.com/puppetlabs-operations/puppet-puppet/pull/166) and allows the latest version of metadata-json-lint to be used, based on the conflicting dependency being resolved in metadata-json-lint.