### PR TITLE
Refactor the way packages are handled

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -49,6 +49,7 @@ class puppet::agent(
   $method            = $puppet::params::default_method,
   $gentoo_use        = $puppet::params::agent_use,
   $gentoo_keywords   = $puppet::params::agent_keywords,
+  $packages          = $puppet::params::agent_package,
   $manage_package    = true,
   $stringify_facts   = false,
 ) inherits puppet::params {
@@ -56,6 +57,7 @@ class puppet::agent(
   include puppet
   if $manage_package {
     include puppet::package
+    realize(Package[$packages])
   }
 
   if $report_server {

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -1,4 +1,10 @@
-class puppet::package {
+class puppet::package (
+  $agent_package  = $puppet::params::agent_package,
+  $master_package = $puppet::params::master_package,
+) inherits puppet::params {
+
+  $packages = union([$agent_package], [$master_package])
+  @package { $packages: }
 
   include puppet::params
 
@@ -9,15 +15,4 @@ class puppet::package {
   if $::operatingsystem == 'gentoo' {
     include puppet::package::gentoo
   }
-
-  package { $puppet::params::agent_package:
-    ensure => $puppet::agent::ensure;
-  }
-
-  if $puppet::server::master and ($puppet::params::master_package != $puppet::params::agent_package) {
-    package { $puppet::params::master_package:
-      ensure => $puppet::server::ensure;
-    }
-  }
-
 }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -38,6 +38,7 @@ class puppet::server (
   $environmentpath    = undef,
   $gentoo_keywords    = $puppet::params::master_keywords,
   $gentoo_use         = $puppet::params::master_use,
+  $packages           = $puppet::params::master_package,
   $manage_package     = true,
   $manifest           = '$confdir/modules/site/site.pp',
   $modulepath         = ['$confdir/modules/site', '$confdir/env/$environment/dist'],
@@ -62,6 +63,7 @@ class puppet::server (
   include puppet::server::config
   if $manage_package {
     include puppet::package
+    realize(Package[$packages])
   }
 
   # ---


### PR DESCRIPTION
This code allows the package for both the master and the agent to be
named the same, while avoiding namespace collisions using the union()
function.  An added benefit here is that the user may specify a custom
package name for the master or the agent.  This may come in handy for
users who wish to use something newer, like puppet-server.