### PR TITLE
(issue #179) Update metadata.json to 0.13.1

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "ploperations-puppet",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "source": "https://github.com/puppetlabs-operations/puppet-puppet",
   "author": "Puppet Labs Operations",
   "license": "Apache-2.0",


### PR DESCRIPTION
This updates metadata.json to 0.13.1 to allow a forge bugfix release.

This addresses @tampakrap's request from issue https://github.com/puppetlabs-operations/puppet-puppet/issues/179.

When this is merged, I will do a manual forge release.