### PR TITLE
Yet another try to refactor the package installation

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -51,6 +51,7 @@ class puppet::agent(
   $gentoo_keywords   = $puppet::params::agent_keywords,
   $manage_package    = true,
   $stringify_facts   = false,
+  $package           = $puppet::params::agent_package,
 ) inherits puppet::params {
 
   include puppet

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -47,8 +47,6 @@ class puppet::agent(
   $configtimeout     = 360,
   $usecacheonfailure = true,
   $method            = $puppet::params::default_method,
-  $gentoo_use        = $puppet::params::agent_use,
-  $gentoo_keywords   = $puppet::params::agent_keywords,
   $manage_package    = true,
   $stringify_facts   = false,
   $package           = $puppet::params::agent_package,

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -1,7 +1,5 @@
 class puppet::package {
 
-  include puppet::params
-
   if $puppet::agent::manage_repos {
     include puppet::package::repository
   }
@@ -10,7 +8,7 @@ class puppet::package {
     include puppet::package::gentoo
   }
 
-  package { $puppet::params::agent_package:
+  package { $puppet::agent::package:
     ensure => $puppet::agent::ensure;
   }
 

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -14,10 +14,4 @@ class puppet::package {
     ensure => $puppet::agent::ensure;
   }
 
-  if $puppet::server::master and ($puppet::params::master_package != $puppet::params::agent_package) {
-    package { $puppet::params::master_package:
-      ensure => $puppet::server::ensure;
-    }
-  }
-
 }

--- a/manifests/package/gentoo.pp
+++ b/manifests/package/gentoo.pp
@@ -1,35 +1,28 @@
-class puppet::package::gentoo {
-
-  include puppet::agent
-  include puppet::params
-
-  if $puppet::server::master {
-    include puppet::server
-    $keywords = $puppet::server::gentoo_keywords
-    $package  = $puppet::params::master_package
-    $use      = $puppet::server::gentoo_use
-  } else {
-    $keywords = $puppet::agent::gentoo_keywords
-    $package  = $puppet::params::agent_package
-    $use      = $puppet::agent::gentoo_use
-  }
+class puppet::package::gentoo (
+  $keywords,
+  $use,
+) {
 
   package_use { 'sys-apps/net-tools':
     use    => 'old-output',
     target => 'puppet',
-    before => Package[$package],
+    before => Package[$puppet::agent::package],
   }
 
-  package_keywords { $package:
-    keywords => $keywords,
-    target   => 'puppet',
-    before   => Package[$package],
+  if $keywords {
+    package_keywords { $puppet::agent::package:
+      keywords => $keywords,
+      target   => 'puppet',
+      before   => Package[$puppet::agent::package],
+    }
   }
 
-  package_use { $package:
-    use    => $use,
-    target => 'puppet',
-    before => Package[$package],
+  if $use {
+    package_use { $puppet::agent::package:
+      use    => $use,
+      target => 'puppet',
+      before => Package[$puppet::agent::package],
+    }
   }
 
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -36,9 +36,7 @@ class puppet::params {
     'gentoo': {
       $os_specific = {
         agent_package  => 'app-admin/puppet',
-        agent_use      => ['minimal'],
         master_package => 'app-admin/puppet',
-        master_use     => ['-minimal'],
       }
     }
     'openbsd': {

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -39,8 +39,6 @@ class puppet::server (
   $environmentpath    = undef,
   $basemodulepath     = undef,
   $default_manifest   = undef,
-  $gentoo_keywords    = $puppet::params::master_keywords,
-  $gentoo_use         = $puppet::params::master_use,
   $manage_package     = true,
   $manifest           = '$confdir/modules/site/site.pp',
   $modulepath         = ['$confdir/modules/site', '$confdir/env/$environment/dist'],

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -57,6 +57,7 @@ class puppet::server (
   $servertype         = 'unicorn',
   $storeconfigs       = undef,
   $stringify_facts    = false,
+  $package            = $puppet::params::master_package,
 ) inherits puppet::params {
 
   validate_bool($directoryenvs)
@@ -64,8 +65,8 @@ class puppet::server (
   include puppet
   include puppet::server::config
 
-  if $manage_package and ($puppet::params::agent_package != $puppet::params::master_package) {
-    package { $puppet::params::master_package:
+  if $manage_package and ($puppet::agent::package != $package) {
+    package { $package:
       ensure => $ensure;
     }
   }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -59,14 +59,15 @@ class puppet::server (
   $stringify_facts    = false,
 ) inherits puppet::params {
 
-  $master = true
-
   validate_bool($directoryenvs)
 
   include puppet
   include puppet::server::config
-  if $manage_package {
-    include puppet::package
+
+  if $manage_package and ($puppet::params::agent_package != $puppet::params::master_package) {
+    package { $puppet::params::master_package:
+      ensure => $ensure;
+    }
   }
 
   # ---

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -26,7 +26,6 @@ PuppetSpecFacts.facts_for_platform_by_name(["Debian_wheezy_7.7_amd64_3.7.2_struc
 
     context "running on #{name}" do
       ['standalone','passenger','unicorn','thin'].each do |server_type|
-#        manage_repos = false if facthash['osfamily'] == 'FreeBSD'
         context "servertype => #{server_type}" do
           let(:params) {{
             :servertype   => server_type,
@@ -47,7 +46,6 @@ PuppetSpecFacts.facts_for_platform_by_name(["Debian_wheezy_7.7_amd64_3.7.2_struc
           it_behaves_like "all puppet master types"
           it_behaves_like "basic puppetmaster environment config"
 
-          #it_behaves_like "agent examples"
           case server_type
             when 'standalone'
             it {
@@ -79,6 +77,16 @@ PuppetSpecFacts.facts_for_platform_by_name(["Debian_wheezy_7.7_amd64_3.7.2_struc
                 should contain_file('/etc/thin.d/puppetmaster.yml')
               }
           end
+        end
+      end
+
+      context "manage_package => false" do
+        let(:params) {{ :manage_package => false }}
+        case facthash['osfamily']
+          when 'RedHat'
+            it { should_not contain_package('puppet-server') }
+          when 'Debian'
+            it { should_not contain_package('puppetmaster') }
         end
       end
     end

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -21,7 +21,7 @@ shared_examples_for "basic puppetmaster environment config" do
 end
 
 PuppetSpecFacts.facts_for_platform_by_name(["Debian_wheezy_7.7_amd64_3.7.2_structured", "Ubuntu_precise_12.04_amd64_PE-3.3.2_stringified", "Ubuntu_trusty_14.04_amd64_PE-3.3.2_stringified"]).each do |name, facthash|
-describe "puppet::server" do
+  describe "puppet::server" do
     let(:facts) { facthash }
 
     context "running on #{name}" do

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -3,7 +3,6 @@ require 'spec_helper'
 shared_examples_for "all puppet master types" do
   it { should compile.with_all_deps }
   it { should contain_class('puppet::server') }
-  it { should contain_class('puppet::package') }
   it { should contain_class('puppet::params') }
   it { should contain_class('puppet::server::config') }
 end


### PR DESCRIPTION
908319b:
Cleanup puppet::class::gentoo based on the previous commits

* Move $gentoo_{keywords,use} to puppet::package::gentoo
* Don't provide any default keywords or useflags, the distro defaults are fine.
  Users of the puppet server have to manually specify keywords = '-minimal' at
  least, in their hiera data

2fcc392:
Add ability for custom package names

Allow overriding the default distro package names by specifying
$puppet::agent::package and $puppet::server::package

This is also useful if people want to install puppetserver instead of
puppet-master

60f0c03:
Move the master package installation back to $puppet::server

It causes unnecessary complexity otherwise in the class ordering