### PR TITLE
Add OpenBSD server support

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -27,7 +27,7 @@ class puppet::server::config {
     'modulepath':
       ensure  => $mod_ensure,
       setting => 'modulepath',
-      value   => join($puppet::server::modulepath, ':');
+      value   => join(flatten([$puppet::server::modulepath]), ':');
 
     'manifest':
       ensure  => $mod_ensure,
@@ -36,10 +36,10 @@ class puppet::server::config {
 
     'user':
       setting => 'user',
-      value   => 'puppet';
+      value   => $puppet::params::puppet_user;
     'group':
       setting => 'group',
-      value   => 'puppet';
+      value   => $puppet::params::puppet_group;
 
     'stringify_facts_master':
       setting => 'stringify_facts',

--- a/spec/classes/server_config_spec.rb
+++ b/spec/classes/server_config_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+openbsdfacts = {:operatingsystem => 'OpenBSD'}
+
+describe "puppet::server::config" do
+  context "on OpenBSD" do
+    let(:facts) { openbsdfacts }
+
+    it { should contain_ini_setting('group').with_value('_puppet') }
+    it { should contain_ini_setting('user').with_value('_puppet') }
+  end
+end


### PR DESCRIPTION
Without this change, the module adds incorrect values to puppet.conf for
the user and group that the puppetmasterd process should run as.  This
corrects that behavior and adds a test.

Here also we implement the flatten function so in cases where the
modulepath is not an array, the run is able to continue unimpeded.