### PR TITLE
Test for correct OpenBSD agent service management

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -43,17 +43,18 @@ class puppet::params {
     }
     'openbsd': {
       $os_specific = {
-        puppet_cmd     => '/usr/local/bin/puppet',
-        agent_service  => 'puppetd',
-        master_package => 'puppet',
-        master_service => 'puppetmasterd',
-        puppet_logdir  => '/var/puppet/log',
-        puppet_vardir  => '/var/puppet',
-        puppet_ssldir  => '/etc/puppet/ssl',
-        puppet_rundir  => '/var/puppet/run',
-        default_method => 'service',
-        puppet_user    => '_puppet',
-        puppet_group   => '_puppet',
+        puppet_cmd         => '/usr/local/bin/puppet',
+        agent_service      => 'puppetd',
+        agent_service_conf => undef,
+        master_package     => 'puppet',
+        master_service     => 'puppetmasterd',
+        puppet_logdir      => '/var/puppet/log',
+        puppet_vardir      => '/var/puppet',
+        puppet_ssldir      => '/etc/puppet/ssl',
+        puppet_rundir      => '/var/puppet/run',
+        default_method     => 'service',
+        puppet_user        => '_puppet',
+        puppet_group       => '_puppet',
       }
     }
     # This stops the puppet class breaking. But really, we only have very

--- a/spec/classes/agent_config_spec.rb
+++ b/spec/classes/agent_config_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+openbsdfacts = {:operatingsystem => 'OpenBSD', :kernel => 'OpenBSD'}
+
+describe "puppet::agent::service" do
+  context "on OpenBSD" do
+    let(:facts) { openbsdfacts }
+
+    it { should_not contain_file('puppet_agent_service_conf') }
+  end
+end


### PR DESCRIPTION
Without this change, the module attempts to manage the service file
configuration on OpenBSD due to it being expected by default.  This is
not so on OpenBSD and causes the run to break.  This fix simply adds the
undef value for the option and includes a test to avoid future
breakages.