### PR TITLE
Move [main] config items to puppet::config class

### DIFF
--- a/manifests/agent/config.pp
+++ b/manifests/agent/config.pp
@@ -1,4 +1,5 @@
 class puppet::agent::config {
+
   include puppet
   include puppet::agent
   include puppet::params
@@ -35,33 +36,9 @@ class puppet::agent::config {
   }
 
   ini_setting { 'pluginsync':
-    section => 'main',
+    section => 'agent',
     setting => 'pluginsync',
     value   => $puppet::agent::pluginsync,
-  }
-
-  ini_setting { 'logdir':
-    section => 'main',
-    setting => 'logdir',
-    value   => $puppet::logdir,
-  }
-
-  ini_setting { 'vardir':
-    section => 'main',
-    setting => 'vardir',
-    value   => $puppet::vardir,
-  }
-
-  ini_setting { 'ssldir':
-    section => 'main',
-    setting => 'ssldir',
-    value   => $puppet::ssldir,
-  }
-
-  ini_setting { 'rundir':
-    section => 'main',
-    setting => 'rundir',
-    value   => $puppet::rundir,
   }
 
   ini_setting { 'certname':
@@ -107,8 +84,8 @@ class puppet::agent::config {
   }
 
   ini_setting { 'stringify_facts_agent':
-      setting => 'stringify_facts',
-      section => 'main',
-      value   => $puppet::agent::stringify_facts;
+    setting => 'stringify_facts',
+    section => 'agent',
+    value   => $puppet::agent::stringify_facts;
   }
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,0 +1,38 @@
+class puppet::config (
+  $logdir  = $puppet::logdir,
+  $vardir  = $puppet::vardir,
+  $ssldir  = $puppet::ssldir,
+  $rundir  = $puppet::rundir,
+  $confdir = $puppet::confdir,
+  $user    = $puppet::user,
+  $group   = $puppet::group,
+  $conf    = $puppet::conf,
+) inherits puppet {
+  include puppet::params
+
+  Ini_setting {
+    path    => $conf,
+    ensure  => 'present',
+    section => 'main',
+  }
+
+  ini_setting { 'logdir':
+    setting => 'logdir',
+    value   => $logdir,
+  }
+
+  ini_setting { 'vardir':
+    setting => 'vardir',
+    value   => $vardir,
+  }
+
+  ini_setting { 'ssldir':
+    setting => 'ssldir',
+    value   => $ssldir,
+  }
+
+  ini_setting { 'rundir':
+    setting => 'rundir',
+    value   => $rundir,
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,7 +15,10 @@ class puppet (
   $confdir = $puppet::params::puppet_confdir,
   $user    = $puppet::params::puppet_user,
   $group   = $puppet::params::puppet_group,
+  $conf    = $puppet::params::puppet_conf,
 ) inherits puppet::params {
+
+  include puppet::config
 
   file { $confdir:
     ensure => 'directory',


### PR DESCRIPTION
This relocates the configuration items that belong in the [main] section
of the puppet.conf file to be namespaced under the puppet::config class.
This follows the pattern for the agent and the master to have specific
pieces belong to each section.  Without this, the puppet::agent::config
is a bit messy, since it places configuration items into the main
section which couples the puppet::agent class to the puppet::master
class.