### PR TITLE
Add support for SRV records

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,14 +1,18 @@
 class puppet::config (
-  $logdir  = $puppet::logdir,
-  $vardir  = $puppet::vardir,
-  $ssldir  = $puppet::ssldir,
-  $rundir  = $puppet::rundir,
-  $confdir = $puppet::confdir,
-  $user    = $puppet::user,
-  $group   = $puppet::group,
-  $conf    = $puppet::conf,
+  $logdir          = $puppet::logdir,
+  $vardir          = $puppet::vardir,
+  $ssldir          = $puppet::ssldir,
+  $rundir          = $puppet::rundir,
+  $confdir         = $puppet::confdir,
+  $user            = $puppet::user,
+  $group           = $puppet::group,
+  $conf            = $puppet::conf,
+  $use_srv_records = false,
+  $srv_domain      = $::domain,
 ) inherits puppet {
   include puppet::params
+
+  validate_bool($use_srv_records)
 
   Ini_setting {
     path    => $conf,
@@ -34,5 +38,29 @@ class puppet::config (
   ini_setting { 'rundir':
     setting => 'rundir',
     value   => $rundir,
+  }
+
+  if $use_srv_records == true {
+    ini_setting { 'use_srv_records':
+      setting => 'use_srv_records',
+      value   => $use_srv_records,
+    }
+
+    ini_setting { 'srv_domain':
+      setting => 'srv_domain',
+      value   => $srv_domain,
+    }
+  } else {
+    ini_setting { 'use_srv_records':
+      ensure  => 'absent',
+      setting => 'use_srv_records',
+      value   => $use_srv_records,
+    }
+
+    ini_setting { 'srv_domain':
+      ensure  => 'absent',
+      setting => 'srv_domain',
+      value   => $srv_domain,
+    }
   }
 }

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe "puppet::config" do
+  let(:facts) {
+    {
+      :operatingsystem => 'OpenBSD',
+      :domain => 'example.com',
+    }
+  }
+
+  context "with srv records enabled" do
+    let(:params) { {:use_srv_records => true} }
+
+      it { should contain_ini_setting('use_srv_records').with_value(true) }
+      it { should contain_ini_setting('srv_domain').with_value('example.com') }
+  end
+
+  context "with srv records disabled" do
+    let(:params) { {:use_srv_records => false} }
+
+      it { should contain_ini_setting('use_srv_records').with_ensure('absent') }
+      it { should contain_ini_setting('srv_domain').with_ensure('absent') }
+  end
+end


### PR DESCRIPTION
This extends the puppet::config class to include two new parameters that
will allow the user to enable or disable SRV record support for master
discovery.