### PR TITLE
Remove travis-lint gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,6 @@ end
 
 group :development do
   gem "travis"
-  gem "travis-lint"
   gem "beaker"
   gem "beaker-rspec"
   gem "vagrant-wrapper"


### PR DESCRIPTION
It is deprecated by `puppet lint` command in travis gem, as stated in
upstream's README