### PR TITLE
WIP: install and configure puppetserver

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -89,6 +89,8 @@ class puppet::params {
     agent_service      => 'puppet',
     agent_service_conf => '/etc/default/puppet',
     default_method     => 'cron',
+    server_package     => 'puppetserver',
+    server_service     => 'puppetserver',
     master_package     => 'puppetmaster',
     master_service     => 'puppetmaster',
     puppet_cmd         => '/usr/bin/puppet',

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -64,7 +64,11 @@ class puppet::server (
   include puppet::server::config
 
   if $manage_package and ($puppet::agent::package != $package) {
-    package { $package:
+    $package_real = $servertype ? {
+      'server' => $puppet::params::server_package,
+      default  => $package,
+    }
+    package { $package_real:
       ensure => $ensure;
     }
   }
@@ -103,8 +107,11 @@ class puppet::server (
     'standalone': {
       include puppet::server::standalone
     }
+    'server': {
+      include puppet::server::server
+    }
     default: {
-      err('Only "passenger", "thin", and "unicorn" are valid options for servertype')
+      err('Only "passenger", "thin", "serverr", and "unicorn" are valid options for servertype')
       fail('Servertype "$servertype" not implemented')
     }
   }

--- a/manifests/server/server.pp
+++ b/manifests/server/server.pp
@@ -1,0 +1,11 @@
+class puppet::server::server {
+  class { 'puppet::server::standalone': enabled => false }
+
+  # configure
+  # lol, no idea, really :(
+
+  service { $puppet::params::server_service:
+    ensure => $puppet::server::ensure
+  }
+
+}


### PR DESCRIPTION
add another option to puppet::server's servertype: server
puppet server is the new form of running the master, built on the same
technology as puppetdb.

this patchset tries to give our users the option to install that product