### PR TITLE
Vagrantfile improvements

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,6 +22,22 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     PUPPETMASTER_IP = '192.168.37.23'
 
+    config.vm.define :debian7 do |node|
+      node.vm.box = 'puppetlabs/debian-7.6-64-nocm'
+      node.vm.hostname = 'debian7.boxnet'
+      config.vm.provider :virtualbox do |vb|
+        vb.customize ["modifyvm", :id, "--memory", "4096", "--cpus", "4", "--ioapic", "on"]
+      end
+    end
+
+    config.vm.define :freebsd10 do |node|
+      node.vm.box = 'chef/freebsd-10.0'
+      node.vm.hostname = 'freebsd10.boxnet'
+      config.vm.provider :virtualbox do |vb|
+        vb.customize ["modifyvm", :id, "--memory", "4096", "--cpus", "4", "--ioapic", "on"]
+      end
+    end
+
     config.vm.define :package_install do |node|
       node.vm.box = 'puppetlabs/debian-7.6-64-nocm'
       node.vm.hostname = 'debian7.boxnet'
@@ -42,7 +58,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
 
     config.vm.define :shared_folder do |node|
-      node.vm.box = 'puppetlabs/debian-7.4-64-nocm'
+      node.vm.box = 'puppetlabs/debian-7.6-64-nocm'
       node.vm.hostname = 'debian7.boxnet'
       node.vm.network :private_network, ip: PUPPETMASTER_IP
 
@@ -62,7 +78,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
 
     config.vm.define :agent do |node|
-      node.vm.box = 'puppetlabs/debian-7.4-64-nocm'
+      node.vm.box = 'puppetlabs/debian-7.6-64-nocm'
       node.vm.hostname = 'debian7agent.boxnet'
       node.vm.network :private_network, ip: "192.168.37.25"
       node.vm.provision "shell",


### PR DESCRIPTION
Bump version of puppetlabs debian vagrantbox, add FreeBSD vagrantbox, and add a simple debian vagrant environment that doesn't install anything automatically, as a sandbox for development.

Both the simple debian environment and FreeBSD vagrantbox have 4gb memory to facilitate puppetserver testing.