### PR TITLE
FreeBSD does not have a Puppet service config

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,13 +9,14 @@ class puppet::params {
     }
     'freebsd': {
       $os_specific = {
-        puppet_cmd     => '/usr/local/bin/puppet',
-        master_package => 'puppet',
-        puppet_conf    => '/usr/local/etc/puppet/puppet.conf',
-        puppet_confdir => '/usr/local/etc/puppet',
-        puppet_logdir  => '/var/log/puppet',
-        puppet_vardir  => '/var/puppet',
-        puppet_ssldir  => '/var/puppet/ssl',
+        puppet_cmd         => '/usr/local/bin/puppet',
+        master_package     => 'puppet',
+        agent_service_conf => undef,
+        puppet_conf        => '/usr/local/etc/puppet/puppet.conf',
+        puppet_confdir     => '/usr/local/etc/puppet',
+        puppet_logdir      => '/var/log/puppet',
+        puppet_vardir      => '/var/puppet',
+        puppet_ssldir      => '/var/puppet/ssl',
       }
     }
     'darwin': {


### PR DESCRIPTION
The config on some Linux distribution to control some aspects of how a
service is managed does not exist on FreeBSD.  This removes attempted
management of that file on FreeBSD.