### PR TITLE
make $puppet::agent::manage_repos work only on RedHat and Debian

### DIFF
--- a/manifests/package/repository.pp
+++ b/manifests/package/repository.pp
@@ -17,10 +17,12 @@ class puppet::package::repository($devel = false) {
   case $::osfamily {
     'Redhat': { $repo_class = 'puppetlabs_yum' }
     'Debian': { $repo_class = 'puppetlabs_apt' }
-    default: { fail("Puppetlabs does not offer a package repository for ${::osfamily}") }
+    default: {}
   }
 
-  class { $repo_class:
-    enable_devel   => $devel,
+  if $::osfamily == 'Redhat' or $::osfamily == 'Debian' {
+    class { $repo_class:
+      enable_devel   => $devel,
+    }
   }
 }


### PR DESCRIPTION
Since these are the only OS families that have PuppetLabs package repositories,
and $manage_repos is on by default, we ended up with broken defaults on other
distros. Thus, we need to make sure it affects only the abovementioned distros