### PR TITLE
Remove ruby 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.6
-  - 2.2.2
 script: bundle exec rake test
 env:
   - PUPPET_VERSION="~> 3.1.0"
@@ -30,4 +29,3 @@ matrix:
     env: PUPPET_VERSION="~> 3.3.0"
   allow_failures:
     - env: PUPPET_VERSION="~> 3.7.5" STRICT_VARIABLES=yes
-    - rvm: 2.2.2


### PR DESCRIPTION
I just noticed that puppet <= 3.7.x won't support ruby 2.2, so it's a waste of
resources to have it on now