### PR TITLE
Added the possibility to create a proxy through the CA

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,19 @@ class { 'puppet::server':
 }
 ```
 
+#### Certificate authority proxy configuration
+
+If you want to automatically relay the certificate requests to an other CA you can do the following :
+```puppet
+class { 'puppet::server':
+  servertype  => 'unicorn',
+  ca          => false,
+  external_ca => 'https://my_puppet_ca_server:8140',
+}
+```
+
+NB: This is only implemented for Nginx/Unicorn configuration so far.
+
 #### Master with PuppetDB, PostgreSQL, and reports
 Running a puppet master without PuppetDB loses much of the utility of Puppet,
 so you probably want it. As a convenience, this module will install puppetdb

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -158,7 +158,7 @@ class puppet::server (
   $servertype        = 'unicorn',
   $storeconfigs      = undef,
   $package           = $puppet::params::master_package,
-  $tagmail           = {}
+  $tagmail           = {},
   $external_ca       = undef,
 ) inherits puppet::params {
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -159,6 +159,7 @@ class puppet::server (
   $storeconfigs      = undef,
   $package           = $puppet::params::master_package,
   $tagmail           = {}
+  $external_ca       = undef,
 ) inherits puppet::params {
 
   validate_bool($ca)

--- a/manifests/server/unicorn.pp
+++ b/manifests/server/unicorn.pp
@@ -74,7 +74,7 @@ class puppet::server::unicorn {
       },
       # this priority sets concat order so that the location is created inside
       # the server block. This works around a possible bug in jfryman/nginx.
-      priority            => 700,
+      priority            => 701,
     }
   }
 

--- a/manifests/server/unicorn.pp
+++ b/manifests/server/unicorn.pp
@@ -59,6 +59,25 @@ class puppet::server::unicorn {
     ],
   }
 
+  if ! empty( $::puppet::server::external_ca )
+  {
+    nginx::resource::location { 'external_certificate_authority_proxy':
+      ensure              => present,
+      location            => '~ ^/.*/certificate.*',
+      vhost               => 'puppetmaster',
+      proxy_set_header    => [],
+      location_custom_cfg => {
+        proxy_pass            => $::puppet::server::external_ca,
+        proxy_redirect        => 'off',
+        proxy_connect_timeout => '90',
+        proxy_read_timeout    => '300',
+      },
+      # this priority sets concat order so that the location is created inside
+      # the server block. This works around a possible bug in jfryman/nginx.
+      priority            => 700,
+    }
+  }
+
   unicorn::app { 'puppetmaster':
     approot     => $::puppet::params::puppet_confdir,
     config_file => "${::puppet::params::puppet_confdir}/unicorn.conf",


### PR DESCRIPTION
Note that on the CA auth.conf this should be enabled too :

```
path /certificate_revocation_list
auth any
method find
allow *
```