### PR TITLE
Move cron minute to class param

### DIFF
--- a/manifests/agent/cron.pp
+++ b/manifests/agent/cron.pp
@@ -2,6 +2,7 @@
 class puppet::agent::cron (
   $enable   = true,
   $run_noop = false,
+  $minute   = fqdn_rand(60),
 ) {
   include puppet::params
 
@@ -20,6 +21,6 @@ class puppet::agent::cron (
   cron { 'puppet agent':
     ensure  => $ensure,
     command => $cmd,
-    minute  => fqdn_rand(60),
+    minute  => $minute,
   }
 }


### PR DESCRIPTION
To allow for modification of the puppet agent run frequency, this work
moves the cron 'minute' up to a class param.