### PR TITLE
Disable plist replacement on OSX

### DIFF
--- a/manifests/agent/service.pp
+++ b/manifests/agent/service.pp
@@ -32,6 +32,7 @@ class puppet::agent::service (
         content => template('puppet/com.puppetlabs.puppet.plist.erb'),
         path    => '/Library/LaunchDaemons/com.puppetlabs.puppet.plist',
         before  => Service['puppet_agent'],
+        replace => false,
       }
     }
     default: {


### PR DESCRIPTION
Due to something oddities with plists and binary interchange formats,
the plist file is rewritten every time Puppet runs.  While its not ideal
to leave a file in place once deployed, changing the file every time is
just noise.

Disabling overwriting the file until a better option is available.