### PR TITLE
[blacksmith] Bump version to 1.0.2

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "ploperations-puppet",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "source": "https://github.com/puppetlabs-operations/puppet-puppet",
   "author": "Puppet Labs Operations",
   "license": "Apache-2.0",


### PR DESCRIPTION
I'm bumping the version to 1.0.2, so that our current in-development version is 1.0.2. The latest released version on Forge is 1.0.1. This gets us ahead of that, so that we can release fixes quickly without awkwardly bumping the version first. If people would prefer the previous way of doing things, I can do that too.
