### PR TITLE
fix tests by calling metadata_lint and removing pe from metadata.json

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -37,5 +37,5 @@ task :test => [
   :syntax,
   :lint,
   :spec,
-  :metadata,
+  :metadata_lint,
 ]

--- a/metadata.json
+++ b/metadata.json
@@ -56,10 +56,6 @@
   ],
   "requirements": [
     {
-      "name": "pe",
-      "version_requirement": "3.x"
-    },
-    {
       "name": "puppet",
       "version_requirement": "3.x"
     }


### PR DESCRIPTION
it fixes the following errors:
The 'metadata' task is deprecated. Please use 'metadata_lint' instead.
The 'pe' requirement is no longer supported by the Forge.
Errors found in metadata.json