### PR TITLE
Add notifier to puppet agent service

### DIFF
--- a/manifests/agent/service.pp
+++ b/manifests/agent/service.pp
@@ -50,6 +50,7 @@ class puppet::agent::service (
           group   => 'root',
           content => template('puppet/agent_service.erb'),
           path    => $puppet::params::agent_service_conf,
+          notify  => Service['puppet_agent'],
         }
       }
     }


### PR DESCRIPTION
This pull request adds a missing notification to puppet agent's service from File[puppet_agent_service_conf].